### PR TITLE
Closes #15 | Add filipino_slang_norm data loader

### DIFF
--- a/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
+++ b/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
@@ -117,8 +117,7 @@ class FilipinoSlangNormDataset(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yield examples as (key, example) tuples"""
         with open(filepath, encoding="utf-8") as f:
-            guid = 0
-            for line in f:
+            for guid, line in enumerate(f):
                 src_sent, norm_sent = line.strip("\n").split(",")
                 if self.config.schema == "source":
                     example = {
@@ -135,4 +134,3 @@ class FilipinoSlangNormDataset(datasets.GeneratorBasedBuilder):
                         "text_2_name": "norm_sent",
                     }
                 yield guid, example
-                guid += 1

--- a/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
+++ b/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
@@ -35,8 +35,8 @@ volunteers.
 _HOMEPAGE = "https://github.com/ljyflores/efficient-spelling-normalization-filipino"
 _LICENSE = Licenses.UNKNOWN.value
 _URLS = {
-    "train": "https://raw.githubusercontent.com/ljyflores/efficient-spelling-normalization-filipino/main/data/train_words.csv",
-    "test": "https://raw.githubusercontent.com/ljyflores/efficient-spelling-normalization-filipino/main/data/test_words.csv",
+    "train": "https://github.com/ljyflores/efficient-spelling-normalization-filipino/raw/main/data/train_words.csv",
+    "test": "https://github.com/ljyflores/efficient-spelling-normalization-filipino/raw/main/data/test_words.csv",
 }
 
 _SUPPORTED_TASKS = [Tasks.MULTILEXNORM]

--- a/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
+++ b/seacrowd/sea_datasets/filipino_slang_norm/filipino_slang_norm.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+from datasets.download.download_manager import DownloadManager
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """
+@inproceedings{flores-radev-2022-look,
+    title = "Look Ma, Only 400 Samples! Revisiting the Effectiveness of Automatic N-Gram Rule Generation for Spelling Normalization in {F}ilipino",
+    author = "Flores, Lorenzo Jaime  and
+      Radev, Dragomir",
+    booktitle = "Proceedings of The Third Workshop on Simple and Efficient Natural Language Processing (SustaiNLP)",
+    month = dec,
+    year = "2022",
+    address = "Abu Dhabi, United Arab Emirates (Hybrid)",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.sustainlp-1.5",
+    pages = "29--35",
+}
+"""
+
+_LOCAL = False
+_LANGUAGES = ["fil"]
+_DATASETNAME = "filipino_slang_norm"
+_DESCRIPTION = """\
+This dataset contains 398 abbreviated and/or contracted Filipino words used in
+Facebook comments made on weather advisories from a Philippine weather bureau.
+volunteers.
+"""
+
+_HOMEPAGE = "https://github.com/ljyflores/efficient-spelling-normalization-filipino"
+_LICENSE = Licenses.UNKNOWN.value
+_URLS = {
+    "train": "https://raw.githubusercontent.com/ljyflores/efficient-spelling-normalization-filipino/main/data/train_words.csv",
+    "test": "https://raw.githubusercontent.com/ljyflores/efficient-spelling-normalization-filipino/main/data/test_words.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.MULTILEXNORM]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class FilipinoSlangNormDataset(datasets.GeneratorBasedBuilder):
+    """Filipino Slang Norm dataset by Flores and Radev (2022)"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    SEACROWD_SCHEMA_NAME = "t2t"
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "src_sent": datasets.Value("string"),
+                    "norm_sent": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text2text_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        data_files = {
+            "train": Path(dl_manager.download_and_extract(_URLS["train"])),
+            "test": Path(dl_manager.download_and_extract(_URLS["test"])),
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_files["train"],
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_files["test"],
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yield examples as (key, example) tuples"""
+        with open(filepath, encoding="utf-8") as f:
+            guid = 0
+            for line in f:
+                src_sent, norm_sent = line.strip("\n").split(",")
+                if self.config.schema == "source":
+                    example = {
+                        "id": str(guid),
+                        "src_sent": src_sent,
+                        "norm_sent": norm_sent,
+                    }
+                elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+                    example = {
+                        "id": str(guid),
+                        "text_1": src_sent,
+                        "text_2": norm_sent,
+                        "text_1_name": "src_sent",
+                        "text_2_name": "norm_sent",
+                    }
+                yield guid, example
+                guid += 1


### PR DESCRIPTION
Closes #15

Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
