### PR TITLE
Closes #5 | Add tatoeba dataset loader

### DIFF
--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -41,7 +41,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class TatoebaDatset(datasets.GeneratorBasedBuilder):
+class TatoebaDataset(datasets.GeneratorBasedBuilder):
     """Tatoeba subset for Indonesian, Vietnamese, Tagalog, Javanese, and Thai."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -98,7 +98,15 @@ class TatoebaDatset(datasets.GeneratorBasedBuilder):
         lang = lang_source.split("_")[0]
         tatoeba_source_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.{lang}")
         tatoeba_eng_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.eng")
-        return [datasets.SplitGenerator(name=datasets.Split.VALIDATION, gen_kwargs={"filepath": (tatoeba_source_data, tatoeba_eng_data), "split": "dev"})]
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": (tatoeba_source_data, tatoeba_eng_data),
+                    "split": "dev",
+                },
+            )
+        ]
 
     def _generate_examples(self, filepath: Tuple[Path, Path], split: str) -> Tuple[int, Dict]:
         """Yield examples as (key, example) tuples"""

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -104,11 +104,12 @@ class TatoebaDatset(datasets.GeneratorBasedBuilder):
                 gen_kwargs={
                     "filepath": (tatoeba_source_data, tatoeba_eng_data),
                     "split": "dev",
+                    "lang": lang,
                 },
             )
         ]
 
-    def _generate_examples(self, filepath: Tuple[Path, Path], split: str) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath: Tuple[Path, Path], split: str, lang: str) -> Tuple[int, Dict]:
         """Yield examples as (key, example) tuples"""
         source_file = filepath[0]
         target_file = filepath[1]
@@ -125,7 +126,9 @@ class TatoebaDatset(datasets.GeneratorBasedBuilder):
                 example = {
                     "source_sentence": source_sentences[idx],
                     "target_sentence": target_sentences[idx],
-                    "source_lang": source_file.split(".")[-1],
+                    # The source_lang in the HuggingFace source seems incorrect
+                    # I am overriding it with the actual language code.
+                    "source_lang": lang,
                     "target_lang": "eng",
                 }
             elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
@@ -133,7 +136,9 @@ class TatoebaDatset(datasets.GeneratorBasedBuilder):
                     "id": str(idx),
                     "text_1": source_sentences[idx],
                     "text_2": target_sentences[idx],
-                    "text_1_name": source_file.split(".")[-1],
+                    # The source_lang in the HuggingFace source seems incorrect
+                    # I am overriding it with the actual language code.
+                    "text_1_name": lang,
                     "text_2_name": "eng",
                 }
             yield idx, example

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -121,7 +121,7 @@ class TatoebaDataset(datasets.GeneratorBasedBuilder):
         tatoeba_source_data = []
         tatoeba_eng_data = []
 
-        lang = self.config.name.split("_")[1] 
+        lang = self.config.name.split("_")[1]
         if lang in _LANGUAGES:
             # Load data per language
             tatoeba_source_data.append(dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.{lang}"))

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -49,7 +49,7 @@ class TatoebaDataset(datasets.GeneratorBasedBuilder):
 
     SEACROWD_SCHEMA_NAME = "t2t"
 
-    dataset_names = sorted([f"tatoeba.{lang}" for lang in _LANGUAGES])
+    dataset_names = sorted([f"tatoeba_{lang}" for lang in _LANGUAGES])
     BUILDER_CONFIGS = []
     for name in dataset_names:
         source_config = SEACrowdConfig(
@@ -94,8 +94,7 @@ class TatoebaDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: DownloadManager) -> List[datasets.SplitGenerator]:
         """Return SplitGenerators."""
-        lang_source = self.config.name.split(".")[1]
-        lang = lang_source.split("_")[0]
+        lang = self.config.name.split("_")[1]
         tatoeba_source_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.{lang}")
         tatoeba_eng_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.eng")
         return [

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -108,10 +108,10 @@ class TatoebaDatset(datasets.GeneratorBasedBuilder):
         target_sentences = []
         with open(source_file, encoding="utf-8") as f1:
             for row in f1:
-                source_sentences.append(row)
+                source_sentences.append(row.strip())
         with open(target_file, encoding="utf-8") as f2:
             for row in f2:
-                target_sentences.append(row)
+                target_sentences.append(row.strip())
         for idx in range(len(source_sentences)):
             if self.config.schema == "source":
                 example = {

--- a/seacrowd/sea_datasets/tatoeba/tatoeba.py
+++ b/seacrowd/sea_datasets/tatoeba/tatoeba.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+from datasets.download.download_manager import DownloadManager
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@article{tatoeba,
+    title     = {Massively Multilingual Sentence Embeddings for Zero-Shot Cross-Lingual Transfer and Beyond},
+    author    = {Mikel, Artetxe and Holger, Schwenk,},
+    journal   = {arXiv:1812.10464v2},
+    year      = {2018}
+}
+"""
+
+_LOCAL = False
+_LANGUAGES = ["ind", "vie", "tgl", "jav", "tha"]
+_DATASETNAME = "tatoeba"
+_DESCRIPTION = """\
+This dataset is a subset of the Tatoeba corpus containing language pairs for Indonesian, Vietnamese, Tagalog, Javanese, and Thai.
+The original dataset description can be found below:
+
+This data is extracted from the Tatoeba corpus, dated Saturday 2018/11/17.
+For each languages, we have selected 1000 English sentences and their translations, if available. Please check
+this paper for a description of the languages, their families and scripts as well as baseline results.
+Please note that the English sentences are not identical for all language pairs. This means that the results are
+not directly comparable across languages. In particular, the sentences tend to have less variety for several
+low-resource languages, e.g. "Tom needed water", "Tom needs water", "Tom is getting water", ...
+"""
+
+_HOMEPAGE = "https://github.com/facebookresearch/LASER/blob/main/data/tatoeba/v1/README.md"
+_LICENSE = Licenses.APACHE_2_0.value
+_URL = "https://github.com/facebookresearch/LASER/raw/main/data/tatoeba/v1/"
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class TatoebaDatset(datasets.GeneratorBasedBuilder):
+    """Tatoeba subset for Indonesian, Vietnamese, Tagalog, Javanese, and Thai."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    SEACROWD_SCHEMA_NAME = "t2t"
+
+    dataset_names = sorted([f"tatoeba.{lang}" for lang in _LANGUAGES])
+    BUILDER_CONFIGS = []
+    for name in dataset_names:
+        source_config = SEACrowdConfig(
+            name=f"{name}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=name,
+        )
+        BUILDER_CONFIGS.append(source_config)
+        seacrowd_config = SEACrowdConfig(
+            name=f"{name}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=name,
+        )
+        BUILDER_CONFIGS.append(seacrowd_config)
+
+    # Choose first language as default
+    DEFAULT_CONFIG_NAME = f"{dataset_names[0]}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "source_sentence": datasets.Value("string"),
+                    "target_sentence": datasets.Value("string"),
+                    "source_lang": datasets.Value("string"),
+                    "target_lang": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text2text_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: DownloadManager) -> List[datasets.SplitGenerator]:
+        """Return SplitGenerators."""
+        lang_source = self.config.name.split(".")[1]
+        lang = lang_source.split("_")[0]
+        tatoeba_source_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.{lang}")
+        tatoeba_eng_data = dl_manager.download_and_extract(_URL + f"tatoeba.{lang}-eng.eng")
+        return [datasets.SplitGenerator(name=datasets.Split.VALIDATION, gen_kwargs={"filepath": (tatoeba_source_data, tatoeba_eng_data), "split": "dev"})]
+
+    def _generate_examples(self, filepath: Tuple[Path, Path], split: str) -> Tuple[int, Dict]:
+        """Yield examples as (key, example) tuples"""
+        source_file = filepath[0]
+        target_file = filepath[1]
+        source_sentences = []
+        target_sentences = []
+        with open(source_file, encoding="utf-8") as f1:
+            for row in f1:
+                source_sentences.append(row)
+        with open(target_file, encoding="utf-8") as f2:
+            for row in f2:
+                target_sentences.append(row)
+        for idx in range(len(source_sentences)):
+            if self.config.schema == "source":
+                example = {
+                    "source_sentence": source_sentences[idx],
+                    "target_sentence": target_sentences[idx],
+                    "source_lang": source_file.split(".")[-1],
+                    "target_lang": "eng",
+                }
+            elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+                example = {
+                    "id": str(idx),
+                    "text_1": source_sentences[idx],
+                    "text_2": target_sentences[idx],
+                    "text_1_name": source_file.split(".")[-1],
+                    "text_2_name": "eng",
+                }
+            yield idx, example


### PR DESCRIPTION
Closes #5

Some notable things to point out from this dataset:
- Instead of implementing one loader per language, I created several configs per language in a single loader. TThis means that the configs would look like this: `tatoeba.ind_seacrowd_t2t`, `tatoeba.ind_source` and so on. When testing, we should pass a value to the `--subset_id` parameter like so:

```
python -m tests.test_seacrowd seacrwod/sea_datasets/tatoeba/tatoeba.py --subset_id tatoeba.ind
```

- The [`source_lang` field in the original HF link](https://huggingface.co/datasets/xtreme/viewer/tatoeba.tgl) seems incorrect?  I'm not familiar with this dataset so for my implementation I just copied over what's in the source. Let me know if I should "override" this with the actual language code.


### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
