### PR TITLE
Add proposed change to venv files in SEACrowd Initialization

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -1,6 +1,6 @@
 name: env-seacrowd
 dependencies:
-  - python>=3.9
+  - python~=3.10.0
   - pip
   - pip:
     - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 loguru==0.5.3
 bioc==1.3.7
-pandas==1.3.3
+pandas==1.3.5
 numpy>=1.22
 pybrat==0.1.4
 datasets>=2.2.0


### PR DESCRIPTION
Reason:
I was trying to follow the steps on creating the venv for this repo (using ```conda version: 23.5.2```) however I encountered some issues when executing conda env create -f conda.yml. It's caused by several requirements conflicting each other for the following points

1. ```pandas==1.3.3``` throws an error on ```subprocess``` with following message:
```Pip subprocess error:
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
....
        File "<string>", line 18, in <module>
      ModuleNotFoundError: No module named 'numpy'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

failed

CondaEnvException: Pip failed
```
2. ```torchaudio==0.11``` isn't compatible with ```python >= 3.11```, only can be installed with at max ```python~=3.10.0```, with following message:
```
Pip subprocess error:
ERROR: Ignored the following yanked versions: 2.0.0
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11
ERROR: Could not find a version that satisfies the requirement torchaudio==0.11 (from versions: 2.0.1, 2.0.2, 2.1.0)
ERROR: No matching distribution found for torchaudio==0.11

failed

CondaEnvException: Pip failed
```