### PR TITLE
Closes #36 | Add COPAL dataloader

### DIFF
--- a/seacrowd/sea_datasets/copal/copal.py
+++ b/seacrowd/sea_datasets/copal/copal.py
@@ -1,0 +1,161 @@
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@article{wibowo2023copal,
+  title={COPAL-ID: Indonesian Language Reasoning with Local Culture and Nuances},
+  author={Wibowo, Haryo Akbarianto and Fuadi, Erland Hilman and Nityasya, Made Nindyatama and Prasojo, Radityo Eko and Aji, Alham Fikri},
+  journal={arXiv preprint arXiv:2311.01012},
+  year={2023}
+}
+"""
+_DATASETNAME = "copal"
+
+_DESCRIPTION = """\
+COPAL is a novel Indonesian language common sense reasoning dataset. Unlike the previous Indonesian COPA dataset (XCOPA-ID), COPAL-ID incorporates Indonesian local and cultural nuances,
+providing a more natural portrayal of day-to-day causal reasoning within the Indonesian cultural sphere.
+Professionally written by natives from scratch, COPAL-ID is more fluent and free from awkward phrases, unlike the translated XCOPA-ID.
+Additionally, COPAL-ID is presented in both standard Indonesian and Jakartan Indonesian–a commonly used dialect.
+It consists of premise, choice1, choice2, question, and label, similar to the COPA dataset.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/haryoaw/COPAL"
+
+_LICENSE = Licenses.CC_BY_SA_4_0.value
+
+_URLS = {
+    _DATASETNAME: {"test": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal.csv?download=true", "test_colloquial": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal_colloquial.csv?download=true"},
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_LOCAL = False
+_LANGUAGES = ["ind"]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class copal(datasets.GeneratorBasedBuilder):
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="copal_source",
+            version=SOURCE_VERSION,
+            description="COPAL test source schema",
+            schema="source",
+            subset_id="copal",
+        ),
+        SEACrowdConfig(
+            name="copal_colloquial_source",
+            version=SOURCE_VERSION,
+            description="COPAL test colloquial source schema",
+            schema="source",
+            subset_id="copal",
+        ),
+        SEACrowdConfig(
+            name="copal_seacrowd_qa",
+            version=SEACROWD_VERSION,
+            description="COPAL test seacrowd schema",
+            schema="seacrowd_qa",
+            subset_id="copal",
+        ),
+        SEACrowdConfig(
+            name="copal_colloquial_seacrowd_qa",
+            version=SEACROWD_VERSION,
+            description="COPAL test colloquial seacrowd schema",
+            schema="seacrowd_qa",
+            subset_id="copal",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "copal_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "premise": datasets.Value("string"),
+                    "choice1": datasets.Value("string"),
+                    "choice2": datasets.Value("string"),
+                    "question": datasets.Value("string"),
+                    "idx": datasets.Value("int64"),
+                    "label": datasets.Value("int64"),
+                    "Terminology": datasets.Value("int64"),
+                    "Culture": datasets.Value("int64"),
+                    "Language": datasets.Value("int64"),
+                }
+            )
+        elif self.config.schema == "seacrowd_qa":
+            features = schemas.qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        if "colloquial" in self.config.name:
+            data_url = data_dir["test_colloquial"]
+        else:
+            data_url = data_dir["test"]
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_url},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": data_url},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        df = pd.read_csv(filepath, sep=",", header="infer").reset_index()
+        if self.config.schema == "source":
+            for row in df.itertuples():
+                entry = {
+                    "premise": row.premise,
+                    "choice1": row.choice1,
+                    "choice2": row.choice2,
+                    "question": row.question,
+                    "idx": row.idx,
+                    "label": row.label,
+                    "Terminology": row.Terminology,
+                    "Culture": row.Culture,
+                    "Language": row.Language,
+                }
+                yield row.index, entry
+
+        elif self.config.schema == "seacrowd_qa":
+            for row in df.itertuples():
+                entry = {
+                    "id": row.idx,
+                    "question_id": str(row.idx),
+                    "document_id": str(row.idx),
+                    "question": row.question,
+                    "type": "multiple_choice",
+                    "choices": [row.choice1, row.choice2],
+                    "context": row.premise,
+                    "answer": [row.choice1 if row.label == 0 else row.choice2],
+                }
+                yield row.index, entry
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/copal/copal.py
+++ b/seacrowd/sea_datasets/copal/copal.py
@@ -31,7 +31,7 @@ _URLS = {
     _DATASETNAME: {"test": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal.csv?download=true", "test_colloquial": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal_colloquial.csv?download=true"},
 }
 
-_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SUPPORTED_TASKS = [Tasks.COMMONSENSE_REASONING]
 
 _LOCAL = False
 _LANGUAGES = ["ind"]
@@ -89,9 +89,9 @@ class copal(datasets.GeneratorBasedBuilder):
                     "question": datasets.Value("string"),
                     "idx": datasets.Value("int64"),
                     "label": datasets.Value("int64"),
-                    "Terminology": datasets.Value("int64"),
-                    "Culture": datasets.Value("int64"),
-                    "Language": datasets.Value("int64"),
+                    "terminology": datasets.Value("int64"),
+                    "culture": datasets.Value("int64"),
+                    "language": datasets.Value("int64"),
                 }
             )
         elif self.config.schema == "seacrowd_qa":
@@ -130,9 +130,9 @@ class copal(datasets.GeneratorBasedBuilder):
                     "question": row.question,
                     "idx": row.idx,
                     "label": row.label,
-                    "Terminology": row.Terminology,
-                    "Culture": row.Culture,
-                    "Language": row.Language,
+                    "terminology": row.Terminology,
+                    "culture": row.Culture,
+                    "language": row.Language,
                 }
                 yield row.index, entry
 
@@ -147,11 +147,8 @@ class copal(datasets.GeneratorBasedBuilder):
                     "choices": [row.choice1, row.choice2],
                     "context": row.premise,
                     "answer": [row.choice1 if row.label == 0 else row.choice2],
+                    "meta": {},
                 }
                 yield row.index, entry
         else:
             raise ValueError(f"Invalid config: {self.config.name}")
-
-
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/copal/copal.py
+++ b/seacrowd/sea_datasets/copal/copal.py
@@ -117,10 +117,6 @@ class copal(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TEST,
                 gen_kwargs={"filepath": data_url},
             ),
-            datasets.SplitGenerator(
-                name=datasets.Split.VALIDATION,
-                gen_kwargs={"filepath": data_url},
-            ),
         ]
 
     def _generate_examples(self, filepath):

--- a/seacrowd/sea_datasets/copal/copal.py
+++ b/seacrowd/sea_datasets/copal/copal.py
@@ -13,7 +13,7 @@ _CITATION = """\
   year={2023}
 }
 """
-_DATASETNAME = "copal"
+_DATASETNAME = "COPAL"
 
 _DESCRIPTION = """\
 COPAL is a novel Indonesian language common sense reasoning dataset. Unlike the previous Indonesian COPA dataset (XCOPA-ID), COPAL-ID incorporates Indonesian local and cultural nuances,
@@ -41,7 +41,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class copal(datasets.GeneratorBasedBuilder):
+class COPAL(datasets.GeneratorBasedBuilder):
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
@@ -96,6 +96,7 @@ class copal(datasets.GeneratorBasedBuilder):
             )
         elif self.config.schema == "seacrowd_qa":
             features = schemas.qa_features
+            features["meta"] = {"terminology": datasets.Value("int64"), "culture": datasets.Value("int64"), "language": datasets.Value("int64")}
 
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
@@ -147,7 +148,7 @@ class copal(datasets.GeneratorBasedBuilder):
                     "choices": [row.choice1, row.choice2],
                     "context": row.premise,
                     "answer": [row.choice1 if row.label == 0 else row.choice2],
-                    "meta": {},
+                    "meta": {"terminology": row.Terminology, "culture": row.Culture, "language": row.Language},
                 }
                 yield row.index, entry
         else:

--- a/seacrowd/sea_datasets/copal/copal.py
+++ b/seacrowd/sea_datasets/copal/copal.py
@@ -13,7 +13,7 @@ _CITATION = """\
   year={2023}
 }
 """
-_DATASETNAME = "COPAL"
+_DATASETNAME = "copal"
 
 _DESCRIPTION = """\
 COPAL is a novel Indonesian language common sense reasoning dataset. Unlike the previous Indonesian COPA dataset (XCOPA-ID), COPAL-ID incorporates Indonesian local and cultural nuances,
@@ -27,9 +27,7 @@ _HOMEPAGE = "https://huggingface.co/datasets/haryoaw/COPAL"
 
 _LICENSE = Licenses.CC_BY_SA_4_0.value
 
-_URLS = {
-    _DATASETNAME: {"test": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal.csv?download=true", "test_colloquial": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal_colloquial.csv?download=true"},
-}
+_URLS = {"test": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal.csv?download=true", "test_colloquial": "https://huggingface.co/datasets/haryoaw/COPAL/resolve/main/test_copal_colloquial.csv?download=true"}
 
 _SUPPORTED_TASKS = [Tasks.COMMONSENSE_REASONING]
 
@@ -48,28 +46,28 @@ class COPAL(datasets.GeneratorBasedBuilder):
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name="copal_source",
+            name=f"{_DATASETNAME}_source",
             version=SOURCE_VERSION,
             description="COPAL test source schema",
             schema="source",
             subset_id="copal",
         ),
         SEACrowdConfig(
-            name="copal_colloquial_source",
+            name=f"{_DATASETNAME}_colloquial_source",
             version=SOURCE_VERSION,
             description="COPAL test colloquial source schema",
             schema="source",
             subset_id="copal",
         ),
         SEACrowdConfig(
-            name="copal_seacrowd_qa",
+            name=f"{_DATASETNAME}_seacrowd_qa",
             version=SEACROWD_VERSION,
             description="COPAL test seacrowd schema",
             schema="seacrowd_qa",
             subset_id="copal",
         ),
         SEACrowdConfig(
-            name="copal_colloquial_seacrowd_qa",
+            name=f"{_DATASETNAME}_colloquial_seacrowd_qa",
             version=SEACROWD_VERSION,
             description="COPAL test colloquial seacrowd schema",
             schema="seacrowd_qa",
@@ -107,8 +105,7 @@ class COPAL(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        urls = _URLS[_DATASETNAME]
-        data_dir = dl_manager.download_and_extract(urls)
+        data_dir = dl_manager.download_and_extract(_URLS)
         if "colloquial" in self.config.name:
             data_url = data_dir["test_colloquial"]
         else:


### PR DESCRIPTION
Closes [#36](https://github.com/SEACrowd/seacrowd-datahub/issues/36)

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
