### PR TITLE
Relates #31 | Add SEACrowd Speech Classification

### DIFF
--- a/seacrowd/utils/constants.py
+++ b/seacrowd/utils/constants.py
@@ -14,6 +14,7 @@ from seacrowd.utils.schemas import (
     ssp_features,
     speech_text_features,
     speech2speech_features,
+    speech_multi_features,
     image_text_features,
 )
 
@@ -78,6 +79,7 @@ class Tasks(Enum):
     # SpeechText
     SPEECH_RECOGNITION = "ASR"
     SPEECH_TO_TEXT_TRANSLATION = "STTT"
+    SPEECH_TO_TEXT_CLASSIFICATION = "STTC"
     TEXT_TO_SPEECH = "TTS"
 
     # SpeechSpeech
@@ -205,6 +207,7 @@ TASK_TO_SCHEMA = {
     Tasks.SPEECH_TO_TEXT_TRANSLATION: "SPTEXT",
     Tasks.TEXT_TO_SPEECH: "SPTEXT",
     Tasks.SPEECH_TO_SPEECH_TRANSLATION: "S2S",
+    Tasks.SPEECH_TO_TEXT_CLASSIFICATION: "SC",
     Tasks.IMAGE_CAPTIONING: "IMTEXT",
     Tasks.STYLIZED_IMAGE_CAPTIONING: "IMTEXT",
     Tasks.VISUALLY_GROUNDED_REASONING: "IMTEXT",
@@ -234,6 +237,7 @@ SCHEMA_TO_FEATURES = {
     "SSP": ssp_features,
     "SPTEXT": speech_text_features,
     "S2S": speech2speech_features,
+    "SC": speech_multi_features(),
     "IMTEXT": image_text_features(),
 }
 

--- a/seacrowd/utils/schemas/__init__.py
+++ b/seacrowd/utils/schemas/__init__.py
@@ -10,6 +10,7 @@ from .seq_label import features as seq_label_features
 from .self_supervised_pretraining import features as ssp_features
 from .speech_text import features as speech_text_features
 from .speech_to_speech import features as speech2speech_features
+from .speech_classification import features as speech_multi_features
 from .image_text import features as image_text_features
 
-__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "pairs_multi_features", "pairs_features_score", "seq_label_features", "ssp_features", "speech_text_features", "speech2speech_features", "image_text_features"]
+__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "pairs_multi_features", "pairs_features_score", "seq_label_features", "ssp_features", "speech_text_features", "speech2speech_features", "speech_multi_features", "image_text_features"]

--- a/seacrowd/utils/schemas/speech_classification.py
+++ b/seacrowd/utils/schemas/speech_classification.py
@@ -1,0 +1,20 @@
+"""
+Speech Classification Schema (Speech to Label, be it binary or multiclass)
+"""
+import datasets
+
+def features(label_names = ["Yes", "No"]):
+    return datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "path": datasets.Value("string"),
+            "audio": datasets.Audio(sampling_rate=16_000),
+            "text": datasets.Value("string"),
+            "speaker_id": datasets.Value("string"),
+            "labels": datasets.Sequence(datasets.ClassLabel(names=label_names)),
+            "metadata": {
+                "speaker_age": datasets.Value("int64"),
+                "speaker_gender": datasets.Value("string"),
+            }
+        }
+    )


### PR DESCRIPTION
It's related to Issue #31 in Fleurs Submission, where the schema of Speech Classification isn't available on SEACrowd Schema and Configs. This PR is created to add a new schema of Speech Classification.

cc @holylovenia @SamuelCahyawijaya 