### PR TITLE
Closes #3  | Create dataset loader for XQuAD

### DIFF
--- a/seacrowd/sea_datasets/xquad/xquad.py
+++ b/seacrowd/sea_datasets/xquad/xquad.py
@@ -47,9 +47,6 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
     with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi.
     """
 
-    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
-    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
-
     subsets = ["xquad", "xquad.vi", "xquad.th"]
 
     BUILDER_CONFIGS = [
@@ -135,7 +132,7 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
                                 "context": context,
                                 "question": question,
                                 "answers": {"answer_start": answers_start, "text": answers_text},
-                                "id": count,
+                                "id": "{}_{}".format(qa["id"], count),
                             }
                         elif self.config.schema == "seacrowd_qa":
                             yield count, {
@@ -143,7 +140,7 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
                                 "context": context,
                                 "question": question,
                                 "answer": {"answer_start": answers_start[0], "text": answers_text[0]},
-                                "id": count,
+                                "id": "{}_{}".format(qa["id"], count),
                                 "choices": [],
                                 "type": "",
                                 "document_id": document_count,

--- a/seacrowd/sea_datasets/xquad/xquad.py
+++ b/seacrowd/sea_datasets/xquad/xquad.py
@@ -47,7 +47,7 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
     with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi.
     """
 
-    subsets = ["xquad", "xquad.vi", "xquad.th"]
+    subsets = ["xquad.vi", "xquad.th"]
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
@@ -90,22 +90,13 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         name_split = self.config.name.split("_")
         subset_name = name_split[0]
-
-        if subset_name == "xquad":
-            # For 'xquad' subset, download and combine Vietnamese and Thai subsets
-            vi_filepath = dl_manager.download_and_extract(_URLS + "xquad.vi.json")
-            th_filepath = dl_manager.download_and_extract(_URLS + "xquad.th.json")
-            filepaths = [vi_filepath, th_filepath]
-        else:
-            # For specific language subsets
-            filepath = dl_manager.download_and_extract(_URLS + subset_name + ".json")
-            filepaths = [filepath]
+        filepath = dl_manager.download_and_extract(_URLS + subset_name + ".json")
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepaths": filepaths,
+                    "filepaths": [filepath],
                     "split": "train",
                 },
             )

--- a/seacrowd/sea_datasets/xquad/xquad.py
+++ b/seacrowd/sea_datasets/xquad/xquad.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -7,7 +6,7 @@ import datasets
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @article{Artetxe:etal:2019,
@@ -24,7 +23,9 @@ _CITATION = """\
 _DATASETNAME = "xquad"
 
 _DESCRIPTION = """\
-XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering performance. The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 (Rajpurkar et al., 2016) together with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi. Consequently, the dataset is entirely parallel across 11 languages.
+XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering performance.
+The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 together
+with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi.
 """
 
 _HOMEPAGE = "https://github.com/google-deepmind/xquad"
@@ -49,7 +50,7 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
-    subsets = ["xquad.vi", "xquad.th"]
+    subsets = ["xquad", "xquad.vi", "xquad.th"]
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
@@ -71,7 +72,7 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
         for subset in subsets
     ]
 
-    DEFAULT_CONFIG_NAME = "xquad.vi_source"
+    DEFAULT_CONFIG_NAME = "xquad_source"
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -91,45 +92,65 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         name_split = self.config.name.split("_")
-        filepath = dl_manager.download_and_extract(_URLS + name_split[0] + ".json")
+        subset_name = name_split[0]
+
+        if subset_name == "xquad":
+            # For 'xquad' subset, download and combine Vietnamese and Thai subsets
+            vi_filepath = dl_manager.download_and_extract(_URLS + "xquad.vi.json")
+            th_filepath = dl_manager.download_and_extract(_URLS + "xquad.th.json")
+            filepaths = [vi_filepath, th_filepath]
+        else:
+            # For specific language subsets
+            filepath = dl_manager.download_and_extract(_URLS + subset_name + ".json")
+            filepaths = [filepath]
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": filepath,
+                    "filepaths": filepaths,
                     "split": "train",
                 },
             )
         ]
 
-    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
-        with open(filepath, encoding="utf-8") as f:
-            data = json.load(f)
-
+    def _generate_examples(self, filepaths: List[Path], split: str) -> Tuple[int, Dict]:
         count = 0
-        for paragraphs in data["data"]:
-            for example in paragraphs["paragraphs"]:
-                context = example["context"]
-                for qa in example["qas"]:
-                    question = qa["question"]
-                    id_ = qa["id"]
-                    answers = qa["answers"]
-                    answers_start = [answer["answer_start"] for answer in answers]
-                    answers_text = [answer["text"] for answer in answers]
+        document_count = 0
+        for filepath in filepaths:
+            with open(filepath, encoding="utf-8") as f:
+                data = json.load(f)
 
-                    if self.config.schema == "source":
-                        yield count, {
-                            "context": context,
-                            "question": question,
-                            "answers": {"answer_start": answers_start, "text": answers_text},
-                            "id": id_,
-                        }
-                        count += 1
+            for paragraphs in data["data"]:
+                for example in paragraphs["paragraphs"]:
+                    context = example["context"]
+                    for qa in example["qas"]:
+                        question = qa["question"]
+                        answers = qa["answers"]
+                        answers_start = [answer["answer_start"] for answer in answers]
+                        answers_text = [answer["text"] for answer in answers]
 
-                    elif self.config.schema == "seacrowd_qa":
-                        yield count, {"question_id": id_, "context": context, "question": question, "answer": {"answer_start": answers_start[0], "text": answers_text[0]}, "id": id_, "choices": [], "type": "extractive", "document_id": count}
+                        if self.config.schema == "source":
+                            yield count, {
+                                "context": context,
+                                "question": question,
+                                "answers": {"answer_start": answers_start, "text": answers_text},
+                                "id": count,
+                            }
+                        elif self.config.schema == "seacrowd_qa":
+                            yield count, {
+                                "question_id": count,
+                                "context": context,
+                                "question": question,
+                                "answer": {"answer_start": answers_start[0], "text": answers_text[0]},
+                                "id": count,
+                                "choices": [],
+                                "type": "extractive",
+                                "document_id": document_count,
+                            }
+
                         count += 1
+                    document_count += 1
 
 
 if __name__ == "__main__":

--- a/seacrowd/sea_datasets/xquad/xquad.py
+++ b/seacrowd/sea_datasets/xquad/xquad.py
@@ -24,8 +24,8 @@ _DATASETNAME = "xquad"
 
 _DESCRIPTION = """\
 XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering performance.
-The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 together
-with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi.
+The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 together (Rajpurkar et al., 2016)
+with their professional translations into ten languages in their original implementation: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi and two in this dataloader: Vietnamese & Thai
 """
 
 _HOMEPAGE = "https://github.com/google-deepmind/xquad"
@@ -145,13 +145,10 @@ class XQuADDataset(datasets.GeneratorBasedBuilder):
                                 "answer": {"answer_start": answers_start[0], "text": answers_text[0]},
                                 "id": count,
                                 "choices": [],
-                                "type": "extractive",
+                                "type": "",
                                 "document_id": document_count,
+                                "meta": {},
                             }
 
                         count += 1
                     document_count += 1
-
-
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/xquad/xquad.py
+++ b/seacrowd/sea_datasets/xquad/xquad.py
@@ -1,0 +1,136 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@article{Artetxe:etal:2019,
+      author    = {Mikel Artetxe and Sebastian Ruder and Dani Yogatama},
+      title     = {On the cross-lingual transferability of monolingual representations},
+      journal   = {CoRR},
+      volume    = {abs/1910.11856},
+      year      = {2019},
+      archivePrefix = {arXiv},
+      eprint    = {1910.11856}
+}
+"""
+
+_DATASETNAME = "xquad"
+
+_DESCRIPTION = """\
+XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering performance. The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 (Rajpurkar et al., 2016) together with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi. Consequently, the dataset is entirely parallel across 11 languages.
+"""
+
+_HOMEPAGE = "https://github.com/google-deepmind/xquad"
+
+_LICENSE = Licenses.CC_BY_SA_4_0.value
+
+_URLS = "https://raw.githubusercontent.com/google-deepmind/xquad/master/"
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class XQuADDataset(datasets.GeneratorBasedBuilder):
+    """
+    XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering performance.
+    The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set of SQuAD v1.1 together
+    with their professional translations into ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    subsets = ["xquad.vi", "xquad.th"]
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="{sub}_source".format(sub=subset),
+            version=datasets.Version(_SOURCE_VERSION),
+            description="{sub} source schema".format(sub=subset),
+            schema="source",
+            subset_id="{sub}".format(sub=subset),
+        )
+        for subset in subsets
+    ] + [
+        SEACrowdConfig(
+            name="{sub}_seacrowd_qa".format(sub=subset),
+            version=datasets.Version(_SEACROWD_VERSION),
+            description="{sub} SEACrowd schema".format(sub=subset),
+            schema="seacrowd_qa",
+            subset_id="{sub}".format(sub=subset),
+        )
+        for subset in subsets
+    ]
+
+    DEFAULT_CONFIG_NAME = "xquad.vi_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {"context": datasets.Value("string"), "question": datasets.Value("string"), "answers": datasets.Features({"answer_start": [datasets.Value("int64")], "text": [datasets.Value("string")]}), "id": datasets.Value("string")}
+            )
+        elif self.config.schema == "seacrowd_qa":
+            features = schemas.qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        name_split = self.config.name.split("_")
+        filepath = dl_manager.download_and_extract(_URLS + name_split[0] + ".json")
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+
+        count = 0
+        for paragraphs in data["data"]:
+            for example in paragraphs["paragraphs"]:
+                context = example["context"]
+                for qa in example["qas"]:
+                    question = qa["question"]
+                    id_ = qa["id"]
+                    answers = qa["answers"]
+                    answers_start = [answer["answer_start"] for answer in answers]
+                    answers_text = [answer["text"] for answer in answers]
+
+                    if self.config.schema == "source":
+                        yield count, {
+                            "context": context,
+                            "question": question,
+                            "answers": {"answer_start": answers_start, "text": answers_text},
+                            "id": id_,
+                        }
+                        count += 1
+
+                    elif self.config.schema == "seacrowd_qa":
+                        yield count, {"question_id": id_, "context": context, "question": question, "answer": {"answer_start": answers_start[0], "text": answers_text[0]}, "id": id_, "choices": [], "type": "extractive", "document_id": count}
+                        count += 1
+
+
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)


### PR DESCRIPTION
Closes #3 

### Notes for reviewer
Because this dataset is multilingual, there are 3 subsets: ["xquad", "xquad.vi", "xquad.th"]. The `xquad` subset, which combines all the languages, is needed because the test requires it. Without it, I ran into this problem running the test:
```
> python -m tests.test_seacrowd seacrowd/sea_datasets/xquad/xquad.py
INFO:__main__:args: Namespace(path='seacrowd/sea_datasets/xquad/xquad.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: seacrowd/sea_datasets/xquad/xquad.py
INFO:__main__:self.SUBSET_ID: xquad
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module seacrowd.sea_datasets.xquad.xquad
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.QUESTION_ANSWERING: 'QA'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'QA'}
INFO:__main__:schemas_to_check: {'QA'}
INFO:__main__:Checking load_dataset with config name xquad_source
/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/load.py:2088: FutureWarning: 'use_auth_token' was deprecated in favor of 'token' in version 2.14.0 and will be removed in 3.0.0.
You can remove this warning by passing 'token=<use_auth_token>' instead.
  warnings.warn(
E
======================================================================
ERROR: runTest (__main__.TestDataLoader.runTest)
Run all tests that check:
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/tests/test_seacrowd.py", line 134, in setUp
    self.dataset_source = datasets.load_dataset(
                          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/load.py", line 2128, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/load.py", line 1851, in load_dataset_builder
    builder_instance: DatasetBuilder = builder_cls(
                                       ^^^^^^^^^^^^
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/builder.py", line 373, in __init__
    self.config, self.config_id = self._create_builder_config(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/builder.py", line 540, in _create_builder_config
    raise ValueError(
ValueError: BuilderConfig 'xquad_source' not found. Available: ['xquad.vi_source', 'xquad.th_source', 'xquad.vi_seacrowd_qa', 'xquad.th_seacrowd_qa']

----------------------------------------------------------------------
Ran 1 test in 0.014s

FAILED (errors=1)
```

Then, because the IDs between language is the same, I ran into this problem running the test:
```
> python -m tests.test_seacrowd seacrowd/sea_datasets/xquad/xquad.py
INFO:__main__:args: Namespace(path='seacrowd/sea_datasets/xquad/xquad.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: seacrowd/sea_datasets/xquad/xquad.py
INFO:__main__:self.SUBSET_ID: xquad
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module seacrowd.sea_datasets.xquad.xquad
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.QUESTION_ANSWERING: 'QA'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'QA'}
INFO:__main__:schemas_to_check: {'QA'}
INFO:__main__:Checking load_dataset with config name xquad_source
/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/load.py:2088: FutureWarning: 'use_auth_token' was deprecated in favor of 'token' in version 2.14.0 and will be removed in 3.0.0.
You can remove this warning by passing 'token=<use_auth_token>' instead.
  warnings.warn(
INFO:__main__:Checking load_dataset with config name xquad_seacrowd_qa
/Users/ilhamfp/Desktop/seacrowd-datahub/seacrowd-env/lib/python3.11/site-packages/datasets/load.py:2088: FutureWarning: 'use_auth_token' was deprecated in favor of 'token' in version 2.14.0 and will be removed in 3.0.0.
You can remove this warning by passing 'token=<use_auth_token>' instead.
  warnings.warn(
Generating train split: 2380 examples [00:00, 31411.28 examples/s]
INFO:__main__:Dataset sample [source]
{'context': 'Đội thủ của Panthers chỉ thua 308 điểm, đứng thứ sáu trong giải đấu, đồng thời dẫn đầu NFL về số lần đoạt bóng (intercept) với 24 lần và tự hào với bốn lựa chọn Pro Bowl. Người húc (tackle) trong đội thủ tham gia Pro Bowl, Kawann Short dẫn đầu đội về số lần vật ngã (sack) với 11 lần, đồng thời húc văng bóng (fumble) 3 lần và lấy lại được bóng (recover) 2 lần. Đồng nghiệp lineman Mario Addison đã thêm 6½ lần vật ngã. Đội hình Panthers cũng có người tiền vệ (defensive end) kỳ cựu Jared Allen, người tham gia Pro Bowl 5 lần, dẫn đầu về số lần vật ngã trong sự nghiệp NFL với 136 lần, cùng với người tiền vệ Kony Ealy, người đã có 5 lần vật ngã sau 9 lần xuất phát. Phía sau họ, hai trong số ba người hàng vệ (linebacker) xuất phát của Panthers cũng được chọn để chơi trong Pro Bowl: Thomas Davis và Luke Kuechly. Davis đã có 5½ lần vật ngã, 4 lần húc văng bóng và 4 lần đoạt bóng, trong khi Kuechly dẫn đầu đội về số lần húc (118 lần), 2 lần húc văng bóng và đoạt bóng từ các đường chuyền 4 lần. Đội hình phía sau của Carolina có hậu-hậu vệ (safety) tham gia Pro Bowl Kurt Coleman, người dẫn đầu đội bóng với bảy lần đoạt bóng trong sự nghiệp, đồng thời có 88 cú húc bóng và trung vệ (cornerback) tham gia Pro Bowl Josh Norman, người đã phát triển thành một shutdown corner trong mùa giải và có bốn lần đoạt bóng, hai trong số đó đã trở thành touchdown.', 'question': 'Đội thủ Panthers đã thua bao nhiêu điểm?', 'answers': {'answer_start': [30], 'text': ['308']}, 'id': '56beb4343aeaaa14008c925b'}
INFO:__main__:Dataset sample [seacrowd_qa]
{'id': '56beb4343aeaaa14008c925b', 'question_id': '56beb4343aeaaa14008c925b', 'document_id': '0', 'question': 'Đội thủ Panthers đã thua bao nhiêu điểm?', 'type': 'extractive', 'choices': [], 'context': 'Đội thủ của Panthers chỉ thua 308 điểm, đứng thứ sáu trong giải đấu, đồng thời dẫn đầu NFL về số lần đoạt bóng (intercept) với 24 lần và tự hào với bốn lựa chọn Pro Bowl. Người húc (tackle) trong đội thủ tham gia Pro Bowl, Kawann Short dẫn đầu đội về số lần vật ngã (sack) với 11 lần, đồng thời húc văng bóng (fumble) 3 lần và lấy lại được bóng (recover) 2 lần. Đồng nghiệp lineman Mario Addison đã thêm 6½ lần vật ngã. Đội hình Panthers cũng có người tiền vệ (defensive end) kỳ cựu Jared Allen, người tham gia Pro Bowl 5 lần, dẫn đầu về số lần vật ngã trong sự nghiệp NFL với 136 lần, cùng với người tiền vệ Kony Ealy, người đã có 5 lần vật ngã sau 9 lần xuất phát. Phía sau họ, hai trong số ba người hàng vệ (linebacker) xuất phát của Panthers cũng được chọn để chơi trong Pro Bowl: Thomas Davis và Luke Kuechly. Davis đã có 5½ lần vật ngã, 4 lần húc văng bóng và 4 lần đoạt bóng, trong khi Kuechly dẫn đầu đội về số lần húc (118 lần), 2 lần húc văng bóng và đoạt bóng từ các đường chuyền 4 lần. Đội hình phía sau của Carolina có hậu-hậu vệ (safety) tham gia Pro Bowl Kurt Coleman, người dẫn đầu đội bóng với bảy lần đoạt bóng trong sự nghiệp, đồng thời có 88 cú húc bóng và trung vệ (cornerback) tham gia Pro Bowl Josh Norman, người đã phát triển thành một shutdown corner trong mùa giải và có bốn lần đoạt bóng, hai trong số đó đã trở thành touchdown.', 'answer': ['answer_start', 'text']}
INFO:__main__:Checking global ID uniqueness
FINFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 2380
question_id: 2380
document_id: 2380
question: 2380
type: 2380
choices: 0
context: 2380
answer: 4760

INFO:__main__:QA ONLY: Checking multiple choice

======================================================================
FAIL: runTest (__main__.TestDataLoader.runTest) [IDs globally unique]
Run all tests that check:
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/tests/test_seacrowd.py", line 71, in runTest
    self.test_are_ids_globally_unique(dataset_seacrowd)
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/tests/test_seacrowd.py", line 234, in test_are_ids_globally_unique
    self._assert_ids_globally_unique(example, ids_seen=ids_seen)
  File "/Users/ilhamfp/Desktop/seacrowd-datahub/tests/test_seacrowd.py", line 219, in _assert_ids_globally_unique
    self.assertNotIn(v, ids_seen)
AssertionError: '56beb4343aeaaa14008c925b' unexpectedly found in {'572750e8dd62a815002e9af2', '5706143575f01819005e7950', '57378c9b1c456719005744a7', '5733a32bd058e614000b5f35', '56e1ee4de3433e1400423214', '5726975c708984140094cb20', '56beb7953aeaaa14008c92af', ...
----------------------------------------------------------------------
Ran 1 test in 0.729s

FAILED (failures=1)
```

I'm not sure what's the best solution for this. But in this PR, I opted to use a `count` as the id instead of the id provided by the dataset. Please let me know if this is a good solution.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
