### PR TITLE
Closes #79 | Add dataloader for Yunshan-Cup-2020 Lao POS

### DIFF
--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -107,21 +107,18 @@ class YunshanCup2020(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
                     "filepath": train_path,
-                    "split": "train",
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "filepath": test_path,
-                    "split": "test",
+                    "filepath": test_path
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
                     "filepath": val_path,
-                    "split": "val",
                 },
             ),
         ]

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -51,7 +51,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class YunshanCup2020(datasets.GeneratorBasedBuilder):
+class YunshanCup2020Dataset(datasets.GeneratorBasedBuilder):
     """Lao POS dataset containing 11,000 sentences was released as part of Yunshan-Cup-2020 evaluation track."""
 
     class_labels = ["IAC", "COJ", "ONM", "PRE", "PRS", "V", "DBQ", "IBQ", "FIX", "N", "ADJ", "DMN", "IAQ", "CLF", "PRA", "DAN", "NEG", "NTR", "REL", "PVA", "TTL", "DAQ", "PRN", "ADV", "PUNCT", "CNM"]

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -57,14 +57,14 @@ class YunshanCup2020(datasets.GeneratorBasedBuilder):
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name="yunshan_cup_2020_source",
+            name=f"{_DATASETNAME}_source",
             version=SOURCE_VERSION,
             description="yunshan_cup_2020 source schema",
             schema="source",
             subset_id="yunshan_cup_2020",
         ),
         SEACrowdConfig(
-            name="yunshan_cup_2020_seacrowd_seq_label",
+            name=f"{_DATASETNAME}_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="yunshan_cup_2020 SEACrowd schema",
             schema="seacrowd_seq_label",

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -126,7 +126,7 @@ class YunshanCup2020(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
         df = load_postagging_data(filepath)
         if self.config.schema == "source":
             for i, row in enumerate(df):

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -1,18 +1,3 @@
-# coding=utf-8
-# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from pathlib import Path
 from typing import Dict, List, Tuple
 

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -39,7 +39,7 @@ _LICENSE = Licenses.UNKNOWN.value  # example: Licenses.MIT.value, Licenses.CC_BY
 
 _URLS = {
     "train": "https://raw.githubusercontent.com/GKLMIP/Yunshan-Cup-2020/main/train.txt",
-    "dev": "https://raw.githubusercontent.com/GKLMIP/Yunshan-Cup-2020/main/dev.txt",
+    "val": "https://raw.githubusercontent.com/GKLMIP/Yunshan-Cup-2020/main/dev.txt",
     "test": "https://raw.githubusercontent.com/GKLMIP/Yunshan-Cup-2020/main/test.txt",
 }
 _SUPPORTED_TASKS = [Tasks.POS_TAGGING]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
@@ -96,9 +96,8 @@ class YunshanCup2020(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        train_path = dl_manager.download_and_extract(_URLS["train"])
-        dev_path = dl_manager.download_and_extract(_URLS["dev"])
-        test_path = dl_manager.download_and_extract(_URLS["test"])
+        path_dict = dl_manager.download_and_extract(_URLS)
+        train_path, val_path, test_path = path_dict["train"], path_dict["val"], path_dict["test"]
 
         return [
             datasets.SplitGenerator(
@@ -118,8 +117,8 @@ class YunshanCup2020(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "filepath": dev_path,
-                    "split": "dev",
+                    "filepath": val_path,
+                    "split": "val",
                 },
             ),
         ]

--- a/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
+++ b/seacrowd/sea_datasets/yunshan_cup_2020/yunshan_cup_2020.py
@@ -22,6 +22,9 @@ _CITATION = """\
  year      = {2022},
  url       = {https://doi.org/10.48550/arXiv.2204.02658},
  doi       = {10.48550/arXiv.2204.02658},
+ eprinttype = {arXiv},
+ eprint    = {2204.02658},
+ timestamp = {Tue, 12 Apr 2022 18:42:14 +0200},
  biburl    = {https://dblp.org/rec/journals/corr/abs-2204-02658.bib},
  bibsource = {dblp computer science bibliography, https://dblp.org}
 }


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #79" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
