### PR TITLE
Closes #84 | Implement CulturaX Dataloader

### DIFF
--- a/seacrowd/sea_datasets/culturax/culturax.py
+++ b/seacrowd/sea_datasets/culturax/culturax.py
@@ -7,7 +7,7 @@ from pyarrow import parquet as pq
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks
+from seacrowd.utils.constants import Tasks, Licenses
 
 _CITATION = """\
 @article{nguyen2023culturax,
@@ -32,7 +32,7 @@ KenLM language models, utilizing recent Wikipedia dumps for perplexity scoring.
 """
 
 _HOMEPAGE = "https://huggingface.co/datasets/uonlp/CulturaX"
-_LICENSE = """
+_LICENSE = f"""{Licenses.OTHERS.value} | \
     The licence terms for CulturaX strictly follows those of mC4 and OSCAR. \
     Please refer to both below licenses when using this dataset. \
     - mC4 license: https://huggingface.co/datasets/allenai/c4#license \

--- a/seacrowd/sea_datasets/culturax/culturax.py
+++ b/seacrowd/sea_datasets/culturax/culturax.py
@@ -45,7 +45,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class CulturaX(datasets.GeneratorBasedBuilder):
+class CulturaXDataset(datasets.GeneratorBasedBuilder):
     """CulturaX subset for SEA languages."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
@@ -58,7 +58,7 @@ class CulturaX(datasets.GeneratorBasedBuilder):
         SEACrowdConfig(
             name=f"{_DATASETNAME}_{subset}_source",
             version=datasets.Version(_SOURCE_VERSION),
-            description=f"{_DATASETNAME}{subset} source schema",
+            description=f"{_DATASETNAME} {subset} source schema",
             schema="source",
             subset_id=subset,
         ) for subset in SUBSETS
@@ -72,8 +72,7 @@ class CulturaX(datasets.GeneratorBasedBuilder):
         )
         for subset in SUBSETS
     ]
-    
-    # choose javanese as default
+
     DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_jv_source"
 
     def _info(self) -> datasets.DatasetInfo:
@@ -121,7 +120,7 @@ class CulturaX(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepaths: [Path], split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples.
-        
+
         Iterate over row groups in each filepaths, then yield each row as an example.
         https://medium.com/munchy-bytes/are-you-using-parquet-with-pandas-in-the-right-way-595c9ee7112
         """
@@ -145,9 +144,3 @@ class CulturaX(datasets.GeneratorBasedBuilder):
                                 "text": row.text,
                             }
                         key += 1
-
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/culturax/culturax.py
+++ b/seacrowd/sea_datasets/culturax/culturax.py
@@ -61,7 +61,8 @@ class CulturaXDataset(datasets.GeneratorBasedBuilder):
             description=f"{_DATASETNAME} {subset} source schema",
             schema="source",
             subset_id=subset,
-        ) for subset in SUBSETS
+        )
+        for subset in SUBSETS
     ] + [
         SEACrowdConfig(
             name=f"{_DATASETNAME}_{subset}_seacrowd_ssp",
@@ -122,7 +123,6 @@ class CulturaXDataset(datasets.GeneratorBasedBuilder):
         """Yields examples as (key, example) tuples.
 
         Iterate over row groups in each filepaths, then yield each row as an example.
-        https://medium.com/munchy-bytes/are-you-using-parquet-with-pandas-in-the-right-way-595c9ee7112
         """
         key = 0
         for filepath in filepaths:


### PR DESCRIPTION
Closes #84 

I implemented one config per language/subset. Thus, configs will look like this: `culturax_id_source`, `culturax_jv_seacrowd_ssp`, etc. When testing, pass `culturax_<subset>` to the `--subset_id` parameter.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
