### PR TITLE
Closes #76 | Create dataset loader for XM3600

### DIFF
--- a/seacrowd/sea_datasets/xm3600/xm3600.py
+++ b/seacrowd/sea_datasets/xm3600/xm3600.py
@@ -59,7 +59,7 @@ _SEACROWD_VERSION = "1.0.0"
 _LANGS = ["fil", "id", "th", "vi"]
 
 
-class XM3600(datasets.GeneratorBasedBuilder):
+class XM3600Dataset(datasets.GeneratorBasedBuilder):
     """
     Crossmodal-3600 dataset (XM3600 in short), a geographically-diverse set of 3600 images annotated with
     human-generated reference captions in 36 languages. The images were selected from across the world,

--- a/seacrowd/sea_datasets/xm3600/xm3600.py
+++ b/seacrowd/sea_datasets/xm3600/xm3600.py
@@ -39,7 +39,6 @@ terms of style across all languages, while avoiding annotation artifacts due to 
 The languages covered in the dataset include Filipino, Indonesian, Thai, and Vietnamnese
 """
 
-
 _HOMEPAGE = "https://google.github.io/crossmodal-3600/"
 
 _LICENSE = Licenses.CC_BY_4_0.value
@@ -58,7 +57,6 @@ _SEACROWD_VERSION = "1.0.0"
 
 _LANGS = ["fil", "id", "th", "vi"]
 
-# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
 class NewDataset(datasets.GeneratorBasedBuilder):
     """
     Crossmodal-3600 dataset (XM3600 in short), a geographically-diverse set of 3600 images annotated with
@@ -111,8 +109,7 @@ class NewDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         captions_path = dl_manager.download_and_extract(_URLS["captions"])
-        images_path = dl_manager.extract("/project/dataset/images.tgz")  # remove on PR
-        # images_path = dl_manager.download_and_extract(_URLS["images"])
+        images_path = dl_manager.download_and_extract(_URLS["images"])
         attr_path = dl_manager.download(_URLS["image_attributions"])
 
         train_caps = {}
@@ -172,7 +169,7 @@ class NewDataset(datasets.GeneratorBasedBuilder):
                         "id": img_id + "_" + str(counter),
                         "image_paths": filepath["images"][img_id],
                         "texts": {
-                            "caption": "".join(l),
+                            "caption": l,
                             "caption/tokenized": cap["caption/tokenized"][cap_index],
                             "caption/tokenized/lowercase": cap["caption/tokenized/lowercase"][cap_index],
                         },

--- a/seacrowd/sea_datasets/xm3600/xm3600.py
+++ b/seacrowd/sea_datasets/xm3600/xm3600.py
@@ -111,8 +111,7 @@ class XM3600(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         captions_path = dl_manager.download_and_extract(_URLS["captions"])
-        # images_path = dl_manager.download_and_extract(_URLS["images"])
-        images_path = dl_manager.download_and_extract("/project/dataset/images.tgz")
+        images_path = dl_manager.download_and_extract(_URLS["images"])
         attr_path = dl_manager.download(_URLS["image_attributions"])
 
         train_caps = {}

--- a/seacrowd/sea_datasets/xm3600/xm3600.py
+++ b/seacrowd/sea_datasets/xm3600/xm3600.py
@@ -71,7 +71,16 @@ class XM3600(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
-    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{lang}_source", version=datasets.Version(_SOURCE_VERSION), description=f"{_DATASETNAME}_{lang} source schema", schema="source", subset_id=f"{_DATASETNAME}_{lang}",) for lang in _LANGS] + [
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{lang}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description=f"{_DATASETNAME}_{lang} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}_{lang}",
+        )
+        for lang in _LANGS
+    ] + [
         SEACrowdConfig(
             name=f"{_DATASETNAME}_{lang}_seacrowd_imtext",
             version=datasets.Version(_SEACROWD_VERSION),
@@ -118,7 +127,6 @@ class XM3600(datasets.GeneratorBasedBuilder):
         test_caps = {}
         val_caps = {}
 
-        print(self.config.subset_id.split("_"))
         current_lang = self.config.subset_id.split("_")[1]
 
         img_df = pd.read_csv(attr_path)
@@ -141,26 +149,23 @@ class XM3600(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
                     "filepath": {"img_ids": img_df_train.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_train.ImageID.values}, "captions": train_caps},
-                    "split": "train",
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
                     "filepath": {"img_ids": img_df_test.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_test.ImageID.values}, "captions": test_caps},
-                    "split": "test",
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
                     "filepath": {"img_ids": img_df_val.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_val.ImageID.values}, "captions": val_caps},
-                    "split": "dev",
                 },
             ),
         ]
 
-    def _generate_examples(self, filepath: dict, split: str) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath: dict) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         counter = 0
         for img_id in filepath["img_ids"]:

--- a/seacrowd/sea_datasets/xm3600/xm3600.py
+++ b/seacrowd/sea_datasets/xm3600/xm3600.py
@@ -1,0 +1,195 @@
+import os
+import jsonlines as jl
+import pandas as pd
+from typing import Dict, List, Tuple
+
+import datasets
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@inproceedings{thapliyal-etal-2022-crossmodal,
+    title = "Crossmodal-3600: A Massively Multilingual Multimodal Evaluation Dataset",
+    author = "Thapliyal, Ashish V.  and
+      Pont Tuset, Jordi  and
+      Chen, Xi  and
+      Soricut, Radu",
+    editor = "Goldberg, Yoav  and
+      Kozareva, Zornitsa  and
+      Zhang, Yue",
+    booktitle = "Proceedings of the 2022 Conference on Empirical Methods in Natural Language Processing",
+    month = dec,
+    year = "2022",
+    address = "Abu Dhabi, United Arab Emirates",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.emnlp-main.45",
+    doi = "10.18653/v1/2022.emnlp-main.45",
+    pages = "715--729",
+}
+"""
+
+_DATASETNAME = "xm3600"
+
+_DESCRIPTION = """\
+Crossmodal-3600 dataset (XM3600 in short), a geographically-diverse set of 3600 images annotated with
+human-generated reference captions in 36 languages. The images were selected from across the world,
+covering regions where the languages are spoken, and annotated with captions that achieve consistency in
+terms of style across all languages, while avoiding annotation artifacts due to direct translation.
+The languages covered in the dataset include Filipino, Indonesian, Thai, and Vietnamnese
+"""
+
+
+_HOMEPAGE = "https://google.github.io/crossmodal-3600/"
+
+_LICENSE = Licenses.CC_BY_4_0.value
+
+_URLS = {
+    "captions": "https://google.github.io/crossmodal-3600/web-data/captions.zip",
+    "images": "https://open-images-dataset.s3.amazonaws.com/crossmodal-3600/images.tgz",
+    "image_attributions": "https://google.github.io/crossmodal-3600/web-data/image_attributions.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.IMAGE_CAPTIONING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+_LANGS = ["fil", "id", "th", "vi"]
+
+# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
+class NewDataset(datasets.GeneratorBasedBuilder):
+    """
+    Crossmodal-3600 dataset (XM3600 in short), a geographically-diverse set of 3600 images annotated with
+    human-generated reference captions in 36 languages. The images were selected from across the world,
+    covering regions where the languages are spoken, and annotated with captions that achieve consistency in
+    terms of style across all languages, while avoiding annotation artifacts due to direct translation.
+    The languages covered in the dataset include Filipino, Indonesian, Thai, and Vietnamnese
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [SEACrowdConfig(name=f"xm3600_{lang}_source", version=datasets.Version(_SOURCE_VERSION), description=f"xm3600_{lang} source schema", schema="source", subset_id=f"xm3600_{lang}",) for lang in _LANGS] + [
+        SEACrowdConfig(
+            name=f"xm3600_{lang}_seacrowd_imtext",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"xm3600_{lang} SEACrowd schema",
+            schema="seacrowd_imtext",
+            subset_id=f"xm3600_{lang}",
+        )
+        for lang in _LANGS
+    ]
+
+    DEFAULT_CONFIG_NAME = "xm3600_id_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "image_paths": datasets.Value("string"),
+                    "texts": {
+                        "caption": datasets.Value("string"),
+                        "caption/tokenized": datasets.Value("string"),
+                        "caption/tokenized/lowercase": datasets.Value("string"),
+                    },
+                }
+            )
+        elif self.config.schema == "seacrowd_imtext":
+            features = schemas.image_text_features()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        captions_path = dl_manager.download_and_extract(_URLS["captions"])
+        images_path = dl_manager.extract("/project/dataset/images.tgz")  # remove on PR
+        # images_path = dl_manager.download_and_extract(_URLS["images"])
+        attr_path = dl_manager.download(_URLS["image_attributions"])
+
+        train_caps = {}
+        test_caps = {}
+        val_caps = {}
+
+        current_lang = self.config.subset_id.split("_")[1]
+
+        img_df = pd.read_csv(attr_path)
+
+        img_df_train = img_df.loc[img_df["Subset"] == "train"][["ImageID", "Subset"]]
+        img_df_test = img_df.loc[img_df["Subset"] == "test"][["ImageID", "Subset"]]
+        img_df_val = img_df.loc[img_df["Subset"] == "validation"][["ImageID", "Subset"]]
+
+        with jl.open(os.path.join(captions_path, "captions.jsonl"), mode="r") as j:
+            for l in j:
+                if l["image/key"] in img_df_train.ImageID.values:
+                    train_caps[l["image/key"]] = l[current_lang]
+                elif l["image/key"] in img_df_test.ImageID.values:
+                    test_caps[l["image/key"]] = l[current_lang]
+                elif l["image/key"] in img_df_val.ImageID.values:
+                    val_caps[l["image/key"]] = l[current_lang]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": {"img_ids": img_df_train.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_train.ImageID.values}, "captions": train_caps},
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": {"img_ids": img_df_test.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_test.ImageID.values}, "captions": test_caps},
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": {"img_ids": img_df_val.ImageID.values, "images": {img_id: os.path.join(images_path, img_id + ".jpg") for img_id in img_df_val.ImageID.values}, "captions": val_caps},
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: dict, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        counter = 0
+        for img_id in filepath["img_ids"]:
+            cap = filepath["captions"][img_id]
+            for l in cap["caption"]:
+                cap_index = cap["caption"].index(l)
+                if self.config.schema == "source":
+                    yield counter, {
+                        "id": img_id + "_" + str(counter),
+                        "image_paths": filepath["images"][img_id],
+                        "texts": {
+                            "caption": "".join(l),
+                            "caption/tokenized": cap["caption/tokenized"][cap_index],
+                            "caption/tokenized/lowercase": cap["caption/tokenized/lowercase"][cap_index],
+                        },
+                    }
+
+                elif self.config.schema == "seacrowd_imtext":
+                    yield counter, {
+                        "id": img_id + "_" + str(counter),
+                        "image_paths": [filepath["images"][img_id]],
+                        "texts": l,
+                        "metadata": {
+                            "context": None,
+                            "labels": None,
+                        },
+                    }
+
+                else:
+                    raise ValueError(f"Invalid config: {self.config.name}")
+
+                counter += 1


### PR DESCRIPTION
Closes #76 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
