### PR TITLE
Closes #78 | Create dataset loader for COCO-35L

### DIFF
--- a/seacrowd/sea_datasets/belebele/belebele.py
+++ b/seacrowd/sea_datasets/belebele/belebele.py
@@ -1,0 +1,166 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Belebele is a multiple-choice machine reading comprehension (MRC) dataset spanning 122 language variants. 
+This dataset enables the evaluation of mono- and multi-lingual models in high-, medium-, and low-resource languages. 
+Each question has four multiple-choice answers and is linked to a short passage from the FLORES-200 dataset. 
+The human annotation procedure was carefully curated to create questions that discriminate between different
+ levels of generalizable language comprehension and is reinforced by extensive quality checks. While all 
+ questions directly relate to the passage, the English dataset on its own proves difficult enough to 
+ challenge state-of-the-art language models. Being fully parallel, this dataset enables direct comparison 
+ of model performance across all languages. Belebele opens up new avenues for evaluating and analyzing
+  the multilingual abilities of language models and NLP systems.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+import json
+import datasets
+import hashlib
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@article{,
+  author    = {Lucas Bandarkar and Davis Liang and Benjamin Muller and Mikel Artetxe and Satya Narayan Shukla and Donald Husa and Naman Goyal and Abhinandan Krishnan and Luke Zettlemoyer and Madian Khabsa},
+  title     = {The Belebele Benchmark: a Parallel Reading Comprehension Dataset in 122 Language Variants},
+  journal   = {arXiv preprint arXiv:2308.16884},
+  year      = {2023},
+  url       = {https://arxiv.org/abs/2308.16884},
+}
+"""
+
+_DATASETNAME = "belebele"
+
+_DESCRIPTION = """\
+Belebele is a multiple-choice machine reading comprehension (MRC) dataset spanning
+ 122 language variants. This dataset enables the evaluation of mono- and multi-lingual 
+ models in high-, medium-, and low-resource languages. 
+ Each question has four multiple-choice answers and is linked to a short passage 
+ from the FLORES-200 dataset. The human annotation procedure was carefully curated 
+ to create questions that discriminate between different levels of generalizable 
+ language comprehension and is reinforced by extensive quality checks. 
+ While all questions directly relate to the passage, the English dataset on its own 
+ proves difficult enough to challenge state-of-the-art language models. 
+ Being fully parallel, this dataset enables direct comparison of model performance 
+ across all languages. Belebele opens up new avenues for evaluating and analyzing 
+ the multilingual abilities of language models and NLP systems.
+"""
+
+_HOMEPAGE = "https://github.com/facebookresearch/belebele"
+
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value
+
+_URLS = {
+    _DATASETNAME: "https://dl.fbaipublicfiles.com/belebele/Belebele.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+_NAMES = ["acm_Arab", "arz_Arab", "ceb_Latn", "fin_Latn", "hin_Deva", "ita_Latn", "khm_Khmr", "lvs_Latn", "npi_Deva", "pol_Latn", "slv_Latn", "swe_Latn", "tso_Latn", "xho_Latn", "afr_Latn", "asm_Beng", "ces_Latn", "fra_Latn", "hin_Latn", "jav_Latn", "kin_Latn", "mal_Mlym", "npi_Latn", "por_Latn", "sna_Latn", "swh_Latn", "tur_Latn", "yor_Latn", "als_Latn", "azj_Latn", "ckb_Arab", "fuv_Latn", "hrv_Latn", "jpn_Jpan", "kir_Cyrl", "mar_Deva", "nso_Latn", "snd_Arab", "tam_Taml", "ukr_Cyrl", "zho_Hans", "amh_Ethi", "bam_Latn", "dan_Latn", "gaz_Latn", "hun_Latn", "kac_Latn", "kor_Hang", "mkd_Cyrl", "nya_Latn", "ron_Latn", "som_Latn", "tel_Telu", "urd_Arab", "zho_Hant", "apc_Arab", "ben_Beng", "deu_Latn", "grn_Latn", "hye_Armn", "kan_Knda", "lao_Laoo", "mlt_Latn", "ory_Orya", "rus_Cyrl", "sot_Latn", "tgk_Cyrl", "urd_Latn", "zsm_Latn", "arb_Arab", "ben_Latn", "ell_Grek", "guj_Gujr", "ibo_Latn", "kat_Geor", "lin_Latn", "mri_Latn", "pan_Guru", "shn_Mymr", "spa_Latn", "tgl_Latn", "uzn_Latn", "zul_Latn", "arb_Latn", "bod_Tibt", "eng_Latn", "hat_Latn", "ilo_Latn", "kaz_Cyrl", "lit_Latn", "mya_Mymr", "pbt_Arab", "sin_Latn", "srp_Cyrl", "tha_Thai", "vie_Latn", "ars_Arab", "bul_Cyrl", "est_Latn", "hau_Latn", "ind_Latn", "kea_Latn", "lug_Latn", "nld_Latn", "pes_Arab", "sin_Sinh", "ssw_Latn", "tir_Ethi", "war_Latn", "ary_Arab", "cat_Latn", "eus_Latn", "heb_Hebr", "isl_Latn", "khk_Cyrl", "luo_Latn", "nob_Latn", "plt_Latn", "slk_Latn", "sun_Latn", "tsn_Latn", "wol_Latn"]
+
+def config_constructor(lang: str, schema: str, version: str) -> SEACrowdConfig:
+    return SEACrowdConfig(
+        name="belebele_{lang}_{schema}".format(lang=lang, schema=schema),
+        version=version,
+        description="belebele {lang} {schema} schema".format(lang=lang, schema=schema),
+        schema=schema,
+        subset_id="belebele",
+    )
+
+class BelebeleDataset(datasets.GeneratorBasedBuilder):
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    BUILDER_CONFIGS = [config_constructor(lang, "source", _SOURCE_VERSION) for lang in _NAMES]
+    BUILDER_CONFIGS.extend((config_constructor(lang, "seacrowd_qa", _SEACROWD_VERSION) for lang in _NAMES))
+    DEFAULT_CONFIG_NAME = "belebele_acm_Arab_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "link": datasets.Value("string"),
+                    "question_number": datasets.Value("int64"),
+                    "flores_passage": datasets.Value("string"),
+                    "question": datasets.Value("string"),
+                    "mc_answer1": datasets.Value("string"), 
+                    "mc_answer2": datasets.Value("string"), 
+                    "mc_answer3": datasets.Value("string"), 
+                    "mc_answer4": datasets.Value("string"), 
+                    "correct_answer_num": datasets.Value("string"), 
+                    "dialect": datasets.Value("string"), 
+                    "ds": datasets.Value("string"), # timedate
+                }
+            ) 
+        elif self.config.schema == "seacrowd_qa":
+            features = schemas.qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        comps = self.config.name.split("_")
+        lang = comps[1]+"_"+comps[2]
+        path = dl_manager.download_and_extract(_URLS[_DATASETNAME])
+        file = "{path}/Belebele/{lang}.jsonl".format(path=path, lang=lang)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "file": file,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, file: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            with open(file, "r", encoding="utf-8") as f: 
+                for key, line in enumerate(f):
+                    line = json.loads(line)
+                    yield key, line
+        elif self.config.schema == "seacrowd_qa":
+            with open(file, "r", encoding="utf-8") as f: 
+                for key, line in enumerate(f):
+                    line = json.loads(line)
+                    choices = [line['mc_answer1'], line['mc_answer2'], line['mc_answer3'], line['mc_answer4']]
+                    answer = choices[int(line['correct_answer_num'])-1]
+                    yield key, {
+                        "id": key,
+                        "question_id": str(line['question_number']),
+                        "document_id": hashlib.md5(line['flores_passage'].encode('utf-8')).hexdigest(),
+                        "question": line['question'],
+                        "type": 'multiple_choice',
+                        "choices": choices,
+                        "context": line['flores_passage'],
+                        "answer": [answer],
+                    }
+        else:
+            raise ValueError(f"Invalid config {self.config.name}")

--- a/seacrowd/sea_datasets/coco_35l/coco_35l.py
+++ b/seacrowd/sea_datasets/coco_35l/coco_35l.py
@@ -75,7 +75,9 @@ class Coco35LDataset(datasets.GeneratorBasedBuilder):
             version=datasets.Version(_SOURCE_VERSION), 
             description=f"{_DATASETNAME}_{lang} source schema", 
             schema="source", 
-            subset_id=f"{_DATASETNAME}_{lang}",) for lang in _LANGS
+            subset_id=f"{_DATASETNAME}_{lang}",
+        ) 
+        for lang in _LANGS
     ] 
     + [
         SEACrowdConfig(

--- a/seacrowd/sea_datasets/coco_35l/coco_35l.py
+++ b/seacrowd/sea_datasets/coco_35l/coco_35l.py
@@ -1,0 +1,197 @@
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import jsonlines as jl
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@inproceedings{thapliyal-etal-2022-crossmodal,
+    title = "Crossmodal-3600: A Massively Multilingual Multimodal Evaluation Dataset",
+    author = "Thapliyal, Ashish V.  and
+      Pont Tuset, Jordi  and
+      Chen, Xi  and
+      Soricut, Radu",
+    editor = "Goldberg, Yoav  and
+      Kozareva, Zornitsa  and
+      Zhang, Yue",
+    booktitle = "Proceedings of the 2022 Conference on Empirical Methods in Natural Language Processing",
+    month = dec,
+    year = "2022",
+    address = "Abu Dhabi, United Arab Emirates",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.emnlp-main.45",
+    doi = "10.18653/v1/2022.emnlp-main.45",
+    pages = "715--729",
+}
+"""
+
+_DATASETNAME = "coco_35l"
+
+_DESCRIPTION = """\
+    COCO-35L is a machine-generated image caption dataset, constructed by translating COCO Captions (Chen et al., 2015) to the other 34 languages using Google’s machine translation API.
+    """
+
+_HOMEPAGE = "https://google.github.io/crossmodal-3600/"
+
+_LICENSE = Licenses.CC_BY_4_0.value
+
+_URLS = {
+    "coco2014_train_images": "http://images.cocodataset.org/zips/train2014.zip",
+    "coco2014_val_images": "http://images.cocodataset.org/zips/val2014.zip",
+    "coco2014_train_val_annots": "http://images.cocodataset.org/annotations/annotations_trainval2014.zip",
+    "trans_train": "https://storage.googleapis.com/crossmodal-3600/coco_mt_train.jsonl.gz",
+    "trans_dev": "https://storage.googleapis.com/crossmodal-3600/coco_mt_dev.jsonl.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.IMAGE_CAPTIONING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+_LANGS = ["fil", "id", "th", "vi"]
+
+
+class COCO35L(datasets.GeneratorBasedBuilder):
+    """
+    COCO-35L is a machine-generated image caption dataset, constructed by translating COCO Captions (Chen et al., 2015) to the other 34 languages using Google’s machine translation API.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{lang}_source", version=datasets.Version(_SOURCE_VERSION), description=f"{_DATASETNAME}_{lang} source schema", schema="source", subset_id=f"{_DATASETNAME}_{lang}",) for lang in _LANGS] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{lang}_seacrowd_imtext",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"{_DATASETNAME}_{lang} SEACrowd schema",
+            schema="seacrowd_imtext",
+            subset_id=f"{_DATASETNAME}_{lang}",
+        )
+        for lang in _LANGS
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_{sorted(_LANGS)[0]}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "image_paths": datasets.Value("string"),
+                    "src_lang": datasets.Value("string"),
+                    "caption_tokenized": datasets.Value("string"),
+                    "trg_lang": datasets.Value("string"),
+                    "translation_tokenized": datasets.Value("string"),
+                    "backtranslation_tokenized": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "seacrowd_imtext":
+            features = schemas.image_text_features()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        trans_train_path = dl_manager.download_and_extract(_URLS["trans_train"])
+        trans_val_path = dl_manager.download_and_extract(_URLS["trans_dev"])
+        coco2014_train_val_annots_path = dl_manager.download_and_extract(_URLS["coco2014_train_val_annots"])
+        coco2014_train_images_path = dl_manager.download_and_extract(_URLS["coco2014_train_images"])
+        coco2014_val_images_path = dl_manager.download_and_extract(_URLS["coco2014_val_images"])
+
+        trans_train_captions = {}
+        trans_dev_captions = {}
+        train_df = pd.DataFrame()
+        val_df = pd.DataFrame()
+
+        current_lang = self.config.subset_id.split("_")[2]
+
+        with open(os.path.join(coco2014_train_val_annots_path, "annotations", "captions_val2014.json")) as json_captions:
+            captions = json.load(json_captions)
+            val_df = pd.DataFrame(captions["images"])
+
+        with open(os.path.join(coco2014_train_val_annots_path, "annotations", "captions_train2014.json")) as json_captions:
+            captions = json.load(json_captions)
+            train_df = pd.DataFrame(captions["images"])
+
+        with jl.open(os.path.join(trans_train_path), mode="r") as j:
+            for line in j:
+                if line["trg_lang"] == current_lang:
+                    trans_img_id = line["image_id"]
+                    trans_train_captions[trans_img_id] = line
+                    coco2014_img_id = int(trans_img_id.split("_")[0])
+                    filename = train_df.query(f"id=={coco2014_img_id}")["file_name"].values[0]
+                    trans_train_captions[trans_img_id]["filename"] = os.path.join(coco2014_train_images_path, "train2014", filename)
+
+        with jl.open(os.path.join(trans_val_path), mode="r") as j:
+            for line in j:
+                if line["trg_lang"] == current_lang:
+                    trans_img_id = line["image_id"]
+                    trans_dev_captions[trans_img_id] = line
+                    coco2014_img_id = int(trans_img_id.split("_")[0])
+                    filename = val_df.query(f"id=={coco2014_img_id}")["file_name"].values[0]
+                    trans_dev_captions[trans_img_id]["filename"] = os.path.join(coco2014_val_images_path, "val2014", filename)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": {
+                        "images": trans_train_captions,
+                    },
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": {
+                        "images": trans_dev_captions,
+                    },
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: dict, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        counter = 0
+        for trans_img_id, data in filepath["images"].items():
+            if self.config.schema == "source":
+                yield counter, {
+                    "id": trans_img_id + "_" + str(counter),
+                    "image_paths": data["filename"],
+                    "src_lang": data["src_lang"],
+                    "caption_tokenized": data["caption_tokenized"],
+                    "trg_lang": data["trg_lang"],
+                    "translation_tokenized": data["translation_tokenized"],
+                    "backtranslation_tokenized": data["backtranslation_tokenized"],
+                }
+
+            elif self.config.schema == "seacrowd_imtext":
+                yield counter, {
+                    "id": trans_img_id + "_" + str(counter),
+                    "image_paths": [data["filename"]],
+                    "texts": data["translation_tokenized"],
+                    "metadata": {
+                        "context": None,
+                        "labels": None,
+                    },
+                }
+
+            else:
+                raise ValueError(f"Invalid config: {self.config.name}")
+
+            counter += 1


### PR DESCRIPTION
Closes #78 
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
