### PR TITLE
Closes #109 | Add Dataloader Asian Parallel Treebank Corpus

### DIFF
--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -1,5 +1,4 @@
 from itertools import combinations
-from pathlib import Path
 from typing import List
 
 import datasets
@@ -34,10 +33,10 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-The ALT project aims to advance the state-of-the-art Asian natural language processing (NLP) techniques through the open collaboration for developing and using ALT. 
-It was first conducted by NICT and UCSY as described in Ye Kyaw Thu, Win Pa Pa, Masao Utiyama, Andrew Finch and Eiichiro Sumita (2016). 
-Then, it was developed under ASEAN IVO. 
-The process of building ALT began with sampling about 20,000 sentences from English Wikinews, and then these sentences were translated into the other languages. 
+The ALT project aims to advance the state-of-the-art Asian natural language processing (NLP) techniques through the open collaboration for developing and using ALT.
+It was first conducted by NICT and UCSY as described in Ye Kyaw Thu, Win Pa Pa, Masao Utiyama, Andrew Finch and Eiichiro Sumita (2016).
+Then, it was developed under ASEAN IVO.
+The process of building ALT began with sampling about 20,000 sentences from English Wikinews, and then these sentences were translated into the other languages.
 ALT now has 13 languages: Bengali, English, Filipino, Hindi, Bahasa Indonesia, Japanese, Khmer, Lao, Malay, Myanmar (Burmese), Thai, Vietnamese, Chinese (Simplified Chinese).
 """
 

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from typing import List
+from itertools import combinations
+
+import datasets
+import json
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME
+
+_DATASETNAME = "parallel_asian_treebank"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
+
+_LANGUAGES = ["khm", "lao", "mya", "ind", "fil", "zlm", "tha", "vie"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_MAPPING_LANGUAGES = { "khm": "khm", "lao": "lo", "mya": "my", "ind": "id", "fil": "fil", "zlm": "ms", "tha": "th", "vie": "vi", }
+_LOCAL = False
+_CITATION = """\
+@inproceedings{riza2016introduction,
+  title={Introduction of the asian language treebank},
+  author={Riza, Hammam and Purwoadi, Michael and Uliniansyah, Teduh and Ti, Aw Ai and Aljunied, Sharifah Mahani and Mai, Luong Chi and Thang, Vu Tat and Thai, Nguyen Phuong and Chea, Vichet and Sam, Sethserey and others},
+  booktitle={2016 Conference of The Oriental Chapter of International Committee for Coordination and Standardization of Speech Databases and Assessment Techniques (O-COCOSDA)},
+  pages={1--6},
+  year={2016},
+  organization={IEEE}
+}
+"""
+
+_DESCRIPTION = """\
+The ALT project aims to advance the state-of-the-art Asian natural language processing (NLP) techniques through the open collaboration for developing and using ALT. 
+It was first conducted by NICT and UCSY as described in Ye Kyaw Thu, Win Pa Pa, Masao Utiyama, Andrew Finch and Eiichiro Sumita (2016). 
+Then, it was developed under ASEAN IVO. 
+The process of building ALT began with sampling about 20,000 sentences from English Wikinews, and then these sentences were translated into the other languages. 
+ALT now has 13 languages: Bengali, English, Filipino, Hindi, Bahasa Indonesia, Japanese, Khmer, Lao, Malay, Myanmar (Burmese), Thai, Vietnamese, Chinese (Simplified Chinese).
+"""
+
+_HOMEPAGE = "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/"
+
+_LICENSE = " Creative Commons Attribution 4.0 International (CC BY 4.0)"
+
+_URLs = {"parallel_asian_treebank": "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/ALT-Parallel-Corpus-20191206.zip"}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
+    """The ALT project aims to advance the state-of-the-art Asian natural language processing (NLP) techniques through the open collaboration for developing and using ALT"""
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=_SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_t2t",
+            version=_SEACROWD_VERSION,
+            description=f"{_DATASETNAME} Nusantara schema",
+            schema="seacrowd_t2t",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "text_1_name": datasets.Value("string"),
+                    "text_2_name": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "seacrowd_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        data_path = dl_manager.download_and_extract(_URLs[_DATASETNAME])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_path
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path):
+
+        mapping_datas = {}
+
+        for language in _LANGUAGES:
+            datas = open(f"{filepath}/ALT-Parallel-Corpus-20191206/data_{_MAPPING_LANGUAGES[language]}.txt", "r").readlines()
+
+            for line in datas:
+                id, sentence = line.split("\t")
+                sentence, _ = sentence.split("\n")
+
+                if id not in mapping_datas:
+                    mapping_datas[id] = {}
+
+                if language not in mapping_datas[id]:
+                    mapping_datas[id][language] = {}
+
+                mapping_datas[id][language] = sentence
+        
+        combination_languages = list(combinations(_LANGUAGES, 2))
+
+        if self.config.schema == "source" or self.config.schema == "seacrowd_t2t":
+            i = 0
+            for id in mapping_datas:
+                for each_pair in combination_languages:
+                    if each_pair[0] in mapping_datas[id] and each_pair[1] in mapping_datas[id]:
+                        yield i, {
+                            "id": f"{id}-{each_pair[0]}-{each_pair[1]}",
+                            "text_1": mapping_datas[id][each_pair[0]],
+                            "text_2": mapping_datas[id][each_pair[1]],
+                            "text_1_name": each_pair[0],
+                            "text_2_name": each_pair[1],
+                        }
+
+                        i+=1
+
+                        yield i, {
+                            "id": f"{id}-{each_pair[1]}-{each_pair[0]}",
+                            "text_1": mapping_datas[id][each_pair[1]],
+                            "text_2": mapping_datas[id][each_pair[0]],
+                            "text_1_name": each_pair[1],
+                            "text_2_name": each_pair[0],
+                        }
+
+                        i+=1
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -12,7 +12,7 @@ _DATASETNAME = "parallel_asian_treebank"
 
 _LANGUAGES = ["khm", "lao", "mya", "ind", "fil", "zlm", "tha", "vie"]
 _LANGUAGES_TO_FILENAME_LANGUAGE_CODE = { "khm": "khm", "lao": "lo", "mya": "my", "ind": "id", "fil": "fil", "zlm": "ms", "tha": "th", "vie": "vi", }
-_LOCAL = False
+_LOCAL = True
 _CITATION = """\
 @inproceedings{riza2016introduction,
   title={Introduction of the asian language treebank},
@@ -89,18 +89,38 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
-        data_path = dl_manager.download_and_extract(_URL)
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": data_path
+                    "data_dir": data_dir,
+                    "split": "train"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "test"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "dev"
                 },
             )
         ]
 
-    def _generate_examples(self, filepath: Path):
+    def _generate_examples(self, data_dir, split: str):
 
         if self.config.schema not in ["source", "seacrowd_t2t"]:
             raise ValueError(f"Invalid config: {self.config.name}")
@@ -108,7 +128,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
         mapping_data = {}
 
         for language in _LANGUAGES:
-            datas = open(f"{filepath}/ALT-Parallel-Corpus-20191206/data_{_LANGUAGES_TO_FILENAME_LANGUAGE_CODE[language]}.txt", "r").readlines()
+            datas = open(f"{data_dir}/data_{_LANGUAGES_TO_FILENAME_LANGUAGE_CODE[language]}.txt.{split}", "r").readlines()
 
             for line in datas:
                 id, sentence = line.split("\t")

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -7,7 +7,7 @@ import json
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME
+from seacrowd.utils.constants import Tasks, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME, Licenses
 
 _DATASETNAME = "parallel_asian_treebank"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
@@ -37,7 +37,7 @@ ALT now has 13 languages: Bengali, English, Filipino, Hindi, Bahasa Indonesia, J
 
 _HOMEPAGE = "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/"
 
-_LICENSE = " Creative Commons Attribution 4.0 International (CC BY 4.0)"
+_LICENSE = Licenses.CC_BY_4_0
 
 _URLs = {"parallel_asian_treebank": "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/ALT-Parallel-Corpus-20191206.zip"}
 

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -63,7 +63,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
+class ParallelAsianTreebankDataset(datasets.GeneratorBasedBuilder):
     """The ALT project aims to advance the state-of-the-art Asian natural language processing (NLP) techniques through the open collaboration for developing and using ALT"""
 
     BUILDER_CONFIGS = []

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -138,7 +138,13 @@ class ParallelAsianTreebankDataset(datasets.GeneratorBasedBuilder):
 
             url_id = [row[0].split(".")[1] for row in rows]
             sent_id = [row[0].split(".")[-1] for row in rows]
-            text = [row[1] for row in rows]
+            text = []
+            for row in rows:
+                # There are rows with an empty text, but they are still tagged with an ID
+                # so we keep them and just pass an empty string.
+                sent = row[1] if len(row) > 1 else ""
+                text.append(sent)
+
 
             df = pd.DataFrame({"url_id": url_id, "sent_id": sent_id, "text": text})
             return df

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -6,11 +6,9 @@ import datasets
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME, Licenses
+from seacrowd.utils.constants import Tasks, Licenses
 
 _DATASETNAME = "parallel_asian_treebank"
-_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
-_UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
 
 _LANGUAGES = ["khm", "lao", "mya", "ind", "fil", "zlm", "tha", "vie"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 _MAPPING_LANGUAGES = { "khm": "khm", "lao": "lo", "mya": "my", "ind": "id", "fil": "fil", "zlm": "ms", "tha": "th", "vie": "vi", }
@@ -36,7 +34,7 @@ ALT now has 13 languages: Bengali, English, Filipino, Hindi, Bahasa Indonesia, J
 
 _HOMEPAGE = "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/"
 
-_LICENSE = Licenses.CC_BY_4_0
+_LICENSE = Licenses.CC_BY_4_0.value
 
 _URLs = {"parallel_asian_treebank": "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/ALT-Parallel-Corpus-20191206.zip"}
 

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -1,17 +1,26 @@
+from itertools import combinations
 from pathlib import Path
 from typing import List
-from itertools import combinations
 
 import datasets
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _DATASETNAME = "parallel_asian_treebank"
 
 _LANGUAGES = ["khm", "lao", "mya", "ind", "fil", "zlm", "tha", "vie"]
-_LANGUAGES_TO_FILENAME_LANGUAGE_CODE = { "khm": "khm", "lao": "lo", "mya": "my", "ind": "id", "fil": "fil", "zlm": "ms", "tha": "th", "vie": "vi", }
+_LANGUAGES_TO_FILENAME_LANGUAGE_CODE = {
+    "khm": "khm",
+    "lao": "lo",
+    "mya": "my",
+    "ind": "id",
+    "fil": "fil",
+    "zlm": "ms",
+    "tha": "th",
+    "vie": "vi",
+}
 _LOCAL = True
 _CITATION = """\
 @inproceedings{riza2016introduction,
@@ -90,34 +99,23 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         if self.config.data_dir is None:
-            raise ValueError(
-                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
-            )
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
         else:
             data_dir = self.config.data_dir
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                gen_kwargs={
-                    "data_dir": data_dir,
-                    "split": "train"
-                },
+                gen_kwargs={"data_dir": data_dir, "split": "train"},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
-                gen_kwargs={
-                    "data_dir": data_dir,
-                    "split": "test"
-                },
+                gen_kwargs={"data_dir": data_dir, "split": "test"},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={
-                    "data_dir": data_dir,
-                    "split": "dev"
-                },
-            )
+                gen_kwargs={"data_dir": data_dir, "split": "dev"},
+            ),
         ]
 
     def _generate_examples(self, data_dir, split: str):
@@ -138,7 +136,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
                     mapping_data[id] = {}
 
                 mapping_data[id][language] = sentence
-        
+
         combination_languages = list(combinations(_LANGUAGES, 2))
 
         i = 0
@@ -154,7 +152,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
                         "text_2_name": each_pair[1],
                     }
 
-                    i+=1
+                    i += 1
 
                     yield i, {
                         "id": f"{id}-{each_pair[1]}-{each_pair[0]}",
@@ -164,4 +162,4 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
                         "text_2_name": each_pair[0],
                     }
 
-                    i+=1
+                    i += 1

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -36,7 +36,7 @@ _HOMEPAGE = "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/"
 
 _LICENSE = Licenses.CC_BY_4_0.value
 
-_URLs = {"parallel_asian_treebank": "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/ALT-Parallel-Corpus-20191206.zip"}
+_URL = "https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/ALT-Parallel-Corpus-20191206.zip"
 
 _SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
 
@@ -89,7 +89,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
-        data_path = dl_manager.download_and_extract(_URLs[_DATASETNAME])
+        data_path = dl_manager.download_and_extract(_URL)
 
         return [
             datasets.SplitGenerator(

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -117,7 +117,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, data_dir, split: str):
+    def _generate_examples(self, data_dir: str, split: str):
 
         if self.config.schema not in ["source", "seacrowd_t2t"]:
             raise ValueError(f"Invalid config: {self.config.name}")
@@ -125,9 +125,9 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
         mapping_data = {}
 
         for language in _LANGUAGES:
-            datas = open(f"{data_dir}/data_{_LANGUAGES_TO_FILENAME_LANGUAGE_CODE[language]}.txt.{split}", "r").readlines()
+            lines = open(f"{data_dir}/data_{_LANGUAGES_TO_FILENAME_LANGUAGE_CODE[language]}.txt.{split}", "r").readlines()
 
-            for line in datas:
+            for line in lines:
                 id, sentence = line.split("\t")
                 sentence = sentence.rsplit()
 

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -3,7 +3,6 @@ from typing import List
 from itertools import combinations
 
 import datasets
-import json
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -75,19 +75,8 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
 
     def _info(self):
-        if self.config.schema == "source":
-            features = datasets.Features(
-                {
-                    "id": datasets.Value("string"),
-                    "text_1": datasets.Value("string"),
-                    "text_2": datasets.Value("string"),
-                    "text_1_name": datasets.Value("string"),
-                    "text_2_name": datasets.Value("string"),
-                }
-            )
-        elif self.config.schema == "seacrowd_t2t":
-            features = schemas.text2text_features
-
+        # The features are the same for both source and seacrowd
+        features = schemas.text2text_features
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,

--- a/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
+++ b/seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py
@@ -58,7 +58,7 @@ class ParallelAsianTreebank(datasets.GeneratorBasedBuilder):
         SEACrowdConfig(
             name=f"{_DATASETNAME}_seacrowd_t2t",
             version=_SEACROWD_VERSION,
-            description=f"{_DATASETNAME} Nusantara schema",
+            description=f"{_DATASETNAME} SEACrowd schema",
             schema="seacrowd_t2t",
             subset_id=_DATASETNAME,
         ),


### PR DESCRIPTION
Closes #109 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/parallel_asian_treebank/parallel_asian_treebank.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

<img width="1120" alt="Screenshot 2023-12-09 at 23 36 34" src="https://github.com/SEACrowd/seacrowd-datahub/assets/11547086/faa1a4d9-d56c-4d60-b678-5fac70f01cef">
<img width="1118" alt="Screenshot 2023-12-09 at 23 36 46" src="https://github.com/SEACrowd/seacrowd-datahub/assets/11547086/ead34a6e-9ce8-4ea2-8b6c-f90dab6a0f0d">


