### PR TITLE
Closes #106 | Create dataset loader for NewsPH

### DIFF
--- a/seacrowd/sea_datasets/newsph/newsph.py
+++ b/seacrowd/sea_datasets/newsph/newsph.py
@@ -1,0 +1,129 @@
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@article{cruz2020investigating,
+  title={Investigating the True Performance of Transformers in Low-Resource Languages: A Case Study in Automatic Corpus Creation},
+  author={Jan Christian Blaise Cruz and Jose Kristian Resabal and James Lin and Dan John Velasco and Charibeth Cheng},
+  journal={arXiv preprint arXiv:2010.11574},
+  year={2020}
+}
+"""
+_DATASETNAME = "newsph"
+_LANGS = ["fil", "tgl"]
+_DESCRIPTION = """\
+Raw collection of news articles in Filipino which can be used for language modelling.
+"""
+_HOMEPAGE = "https://huggingface.co/datasets/newsph"
+_LICENSE = Licenses.GPL_3_0.value
+_LOCAL = False
+_URLS = "https://s3.us-east-2.amazonaws.com/blaisecruz.com/datasets/newsph/newsph-nli.zip"
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class NewsPhDataset(datasets.GeneratorBasedBuilder):
+    """
+    Raw collection of news articles in Filipino which can be used for language modelling.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="newsph_source",
+            version=SOURCE_VERSION,
+            description="newsph source schema",
+            schema="source",
+            subset_id="newsph",
+        ),
+        SEACrowdConfig(
+            name="newsph_seacrowd_pairs",
+            version=SEACROWD_VERSION,
+            description="newsph SEACrowd schema",
+            schema="seacrowd_pairs",
+            subset_id="newsph",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "newsph_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        label_classes = [0, 1]
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "label": datasets.ClassLabel(names=label_classes),
+                }
+            )
+        elif self.config.schema == "seacrowd_pairs":
+            features = schemas.pairs_features(label_classes)
+        else:
+            raise NotImplementedError(f"Schema '{self.config.schema}' is not defined.")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        data_dir = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "newsph-nli", "train.csv"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "newsph-nli", "test.csv"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "newsph-nli", "valid.csv"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source" or self.config.schema == "seacrowd_pairs":
+            df = pd.read_csv(filepath)
+            for key in df.index:
+                yield key, {
+                    "id": str(key),
+                    "text_1": df["s1"][key],
+                    "text_2": df["s2"][key],
+                    "label": df["label"][key],
+                }
+        else:
+            raise NotImplementedError

--- a/seacrowd/sea_datasets/newsph/newsph.py
+++ b/seacrowd/sea_datasets/newsph/newsph.py
@@ -3,30 +3,31 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import datasets
-import pandas as pd
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
-@article{cruz2020investigating,
-  title={Investigating the True Performance of Transformers in Low-Resource Languages: A Case Study in Automatic Corpus Creation},
-  author={Jan Christian Blaise Cruz and Jose Kristian Resabal and James Lin and Dan John Velasco and Charibeth Cheng},
-  journal={arXiv preprint arXiv:2010.11574},
-  year={2020}
+@inproceedings{cruz2021exploiting,
+  title={Exploiting news article structure for automatic corpus generation of entailment datasets},
+  author={Cruz, Jan Christian Blaise and Resabal, Jose Kristian and Lin, James and Velasco, Dan John and Cheng, Charibeth},
+  booktitle={PRICAI 2021: Trends in Artificial Intelligence: 18th Pacific Rim International Conference on Artificial Intelligence, PRICAI 2021, Hanoi, Vietnam, November 8--12, 2021, Proceedings, Part II 18},
+  pages={86--99},
+  year={2021},
+  organization={Springer}
 }
 """
 _DATASETNAME = "newsph"
-_LANGS = ["fil", "tgl"]
+_LANGUAGES = ["fil", "tgl"]
 _DESCRIPTION = """\
 Raw collection of news articles in Filipino which can be used for language modelling.
 """
 _HOMEPAGE = "https://huggingface.co/datasets/newsph"
 _LICENSE = Licenses.GPL_3_0.value
 _LOCAL = False
-_URLS = "https://s3.us-east-2.amazonaws.com/blaisecruz.com/datasets/newsph/newsph-nli.zip"
-_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+_URLS = "https://s3.us-east-2.amazonaws.com/blaisecruz.com/datasets/newsph/newsph.zip"
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
 _SOURCE_VERSION = "1.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
@@ -49,10 +50,10 @@ class NewsPhDataset(datasets.GeneratorBasedBuilder):
             subset_id="newsph",
         ),
         SEACrowdConfig(
-            name="newsph_seacrowd_pairs",
+            name="newsph_seacrowd_ssp",
             version=SEACROWD_VERSION,
             description="newsph SEACrowd schema",
-            schema="seacrowd_pairs",
+            schema="seacrowd_ssp",
             subset_id="newsph",
         ),
     ]
@@ -60,19 +61,15 @@ class NewsPhDataset(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = "newsph_source"
 
     def _info(self) -> datasets.DatasetInfo:
-        label_classes = [0, 1]
-
         if self.config.schema == "source":
             features = datasets.Features(
                 {
                     "id": datasets.Value("string"),
-                    "text_1": datasets.Value("string"),
-                    "text_2": datasets.Value("string"),
-                    "label": datasets.ClassLabel(names=label_classes),
+                    "text": datasets.Value("string"),
                 }
             )
-        elif self.config.schema == "seacrowd_pairs":
-            features = schemas.pairs_features(label_classes)
+        elif self.config.schema == "seacrowd_ssp":
+            features = schemas.self_supervised_pretraining.features
         else:
             raise NotImplementedError(f"Schema '{self.config.schema}' is not defined.")
 
@@ -93,36 +90,20 @@ class NewsPhDataset(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "newsph-nli", "train.csv"),
+                    "filepath": os.path.join(data_dir, "newsph", "train.txt"),
                     "split": "train",
-                },
-            ),
-            datasets.SplitGenerator(
-                name=datasets.Split.TEST,
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, "newsph-nli", "test.csv"),
-                    "split": "test",
-                },
-            ),
-            datasets.SplitGenerator(
-                name=datasets.Split.VALIDATION,
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, "newsph-nli", "valid.csv"),
-                    "split": "dev",
                 },
             ),
         ]
 
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
-        if self.config.schema == "source" or self.config.schema == "seacrowd_pairs":
-            df = pd.read_csv(filepath)
-            for key in df.index:
-                yield key, {
-                    "id": str(key),
-                    "text_1": df["s1"][key],
-                    "text_2": df["s2"][key],
-                    "label": df["label"][key],
-                }
+        if self.config.schema == "source" or self.config.schema == "seacrowd_ssp":
+            with open(filepath, encoding="utf-8") as f:
+                for idx, row in enumerate(f):
+                    if row.strip():
+                        yield idx, {"id": str(idx), "text": row}
+                    else:
+                        yield idx, {"id": str(idx), "text": ""}
         else:
             raise NotImplementedError

--- a/seacrowd/sea_datasets/newsph/newsph.py
+++ b/seacrowd/sea_datasets/newsph/newsph.py
@@ -92,7 +92,6 @@ class NewsPhDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                # Whatever you put in gen_kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "filepath": os.path.join(data_dir, "newsph-nli", "train.csv"),
                     "split": "train",


### PR DESCRIPTION
Closes #106 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
