### PR TITLE
Update stale workflow to avoid Misflag Issue

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,9 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hi, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
-        stale-issue-label: 'no-issue-activity'
+        stale-issue-label: 'staled-issue'
         days-before-stale: 14
         days-before-close: -1
         include-only-assigned: true
+        exempt-issue-labels: 'in-progress,pr-ready'
+        operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,3 +28,4 @@ jobs:
         include-only-assigned: true
         exempt-issue-labels: 'in-progress,pr-ready'
         operations-per-run: 100
+        debug-only: true


### PR DESCRIPTION
Hi @holylovenia and @SamuelCahyawijaya, regarding the mistag GH Actions on marking the staled issue, I found the issue lies in a current workflow that wrongly tags open Issues with a PR attached to it (the mistag issue happens in #24).

The issues are caused due to 2 unexpected behavior:
1. the field of `updated_at` from Github Issue that isn't being updated if a PR closing that issue is being linked
2. The `update_at` field is used by GH Stale Workflow to mark no activity issue.

Hence, marking an issue with a flag of either `pr-ready` or `in progress` is essential to exempt those issues from being checked and marked as Stale Issues.

In addition, I'm proposing to increase the number of operations per run (based on the est. upper bound of open issues that we have right now, 100) so all issues are being scanned (except those with an exempted tag).


Pre-merging To-Do:
- [x] Do a dry-run of issues (if possible)

Post-merging To-Do:
- [ ] Monitor for one week if there is any mistagged issue like the previous occurrence
- [ ] Communicate the new automated workflow in Discord or the next SEACrowd Townhall.
