### PR TITLE
Closes #30 | Add palito dataset

### DIFF
--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -78,16 +78,7 @@ _URLS = {
 class PalitoDataset(datasets.GeneratorBasedBuilder):
     """Palito corpus"""
 
-    subsets = [
-        "palito_bik",
-        "palito_ceb",
-        "palito_hil",
-        "palito_ilo",
-        "palito_tgl",
-        "palito_pam",
-        "palito_pag",
-        "palito_war",
-    ]
+    subsets = [f"{_DATASETNAME}_{lang}" for lang in _LANGUAGES]
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import (DEFAULT_SEACROWD_VIEW_NAME,
+                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
+
+_DATASETNAME = "palito"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
+
+_CITATION = """
+Shirley Dita, Rachel Edita Roxas, Paul Inventado. 2008. Building online corpora of Philippine languages. Proceedings of the 23rd Pacific Asia Conference on Language, Information and Computation. Available online: http://aclweb.org/anthology/Y/Y09/Y09-2024.pdf
+"""
+
+# We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_LANGUAGES = {
+    "bik": "Bikol",
+    "ceb": "Cebuano",
+    "hil": "Hiligaynon",
+    "ilo": "Ilocano",
+    "tgl": "Tagalog",
+    "pam": "Kapampangan",
+    "pag": "Pangasinense",
+    "war": "Waray",
+  }
+
+_LOCAL = False
+
+_DESCRIPTION = """\
+This paper aims at describing the building of the online corpora on Philippine
+languages as part of the online repository system called Palito. There are five components
+of the corpora: the top four major Philippine languages which are Tagalog, Cebuano,
+Ilocano and Hiligaynon and the Filipino Sign Language (FSL). The four languages are
+composed of 250,000-word written texts each, whereas the FSL is composed of seven
+thousand signs in video format. Categories of the written texts include creative writing (such
+as novels and stories) and religious texts (such as the Bible). Automated tools are provided
+for language analysis such as word count, collocates, and others. This is part of a bigger
+corpora building project for Philippine languages that would consider text, speech and
+video forms, and the corresponding development of automated tools for language analysis
+of these various forms. 
+"""
+
+_HOMEPAGE = "https://github.com/imperialite/Philippine-Languages-Online-Corpora/tree/master/PALITO%20Corpus"
+
+_LICENSE = "GNU Lesser General Public License family (lgpl)"
+
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+_URLS = {
+    "literary": "https://raw.githubusercontent.com/imperialite/Philippine-Languages-Online-Corpora/master/PALITO%20Corpus/Data/{lang}_Literary_Text.txt",
+    "religious": "https://raw.githubusercontent.com/imperialite/Philippine-Languages-Online-Corpora/master/PALITO%20Corpus/Data/{lang}_Religious_Text.txt"
+}
+
+
+class Palito(datasets.GeneratorBasedBuilder):
+    """Palito corpus"""
+
+    subsets = [
+        "palito_bik",
+        "palito_ceb",
+        "palito_hil",
+        "palito_ilo",
+        "palito_tgl",
+        "palito_pam",
+        "palito_pag",
+        "palito_war",
+        ]
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="{sub}_source".format(sub=subset),
+            version=datasets.Version(_SOURCE_VERSION),
+            description="Palito {sub} source schema".format(sub=subset),
+            schema="source",
+            subset_id="{sub}".format(sub=subset),
+        )
+        for subset in subsets
+    ] + [
+        SEACrowdConfig(
+            name="{sub}_seacrowd_ssp".format(sub=subset),
+            version=datasets.Version(_SEACROWD_VERSION),
+            description="Palito {sub} SEACrowd schema".format(sub=subset),
+            schema="seacrowd_ssp",
+            subset_id="{sub}".format(sub=subset),
+        )
+        for subset in subsets
+    ]
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "seacrowd_ssp":
+            features = schemas.self_supervised_pretraining.features
+        else:
+            raise ValueError(f"Invalid config schema: {self.config.schema}")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        lang = self.config.name.split("_")[1]
+        filepaths = [Path(dl_manager.download(_URLS["literary"].format(lang=_LANGUAGES[lang]))), 
+                     Path(dl_manager.download(_URLS["religious"].format(lang=_LANGUAGES[lang])))]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepaths": filepaths},
+            ),
+        ]
+
+    def _generate_examples(self, filepaths: list[Path]) -> Tuple[int, Dict]:
+        counter = 0
+        for path in filepaths:
+            with open(path, encoding="utf-8") as f:
+                for line in f.readlines():
+                    if line.strip() == "":
+                        continue
+
+                    if self.config.schema == "source":
+                        yield (
+                            counter,
+                            {
+                                "id": str(counter),
+                                "text": line.strip(),
+                            },
+                        )
+                    elif self.config.schema == "seacrowd_ssp":
+                        yield (
+                            counter,
+                            {
+                                "id": str(counter),
+                                "text": line.strip(),
+                            },
+                        )
+
+                    counter += 1                

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -2,12 +2,11 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import datasets
-import pandas as pd
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import (DEFAULT_SEACROWD_VIEW_NAME,
-                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
+                                      DEFAULT_SOURCE_VIEW_NAME, Tasks)
 
 _DATASETNAME = "palito"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
@@ -40,7 +39,7 @@ _LANGUAGES = {
     "pam": "Kapampangan",
     "pag": "Pangasinense",
     "war": "Waray",
-  }
+}
 
 _LOCAL = False
 
@@ -55,7 +54,7 @@ as novels and stories) and religious texts (such as the Bible). Automated tools 
 for language analysis such as word count, collocates, and others. This is part of a bigger
 corpora building project for Philippine languages that would consider text, speech and
 video forms, and the corresponding development of automated tools for language analysis
-of these various forms. 
+of these various forms.
 """
 
 _HOMEPAGE = "https://github.com/imperialite/Philippine-Languages-Online-Corpora/tree/master/PALITO%20Corpus"
@@ -70,7 +69,7 @@ _SEACROWD_VERSION = "1.0.0"
 
 _URLS = {
     "literary": "https://raw.githubusercontent.com/imperialite/Philippine-Languages-Online-Corpora/master/PALITO%20Corpus/Data/{lang}_Literary_Text.txt",
-    "religious": "https://raw.githubusercontent.com/imperialite/Philippine-Languages-Online-Corpora/master/PALITO%20Corpus/Data/{lang}_Religious_Text.txt"
+    "religious": "https://raw.githubusercontent.com/imperialite/Philippine-Languages-Online-Corpora/master/PALITO%20Corpus/Data/{lang}_Religious_Text.txt",
 }
 
 
@@ -86,7 +85,7 @@ class PalitoDataset(datasets.GeneratorBasedBuilder):
         "palito_pam",
         "palito_pag",
         "palito_war",
-        ]
+    ]
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
@@ -131,8 +130,7 @@ class PalitoDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         lang = self.config.name.split("_")[1]
-        filepaths = [Path(dl_manager.download(_URLS["literary"].format(lang=_LANGUAGES[lang]))), 
-                     Path(dl_manager.download(_URLS["religious"].format(lang=_LANGUAGES[lang])))]
+        filepaths = [Path(dl_manager.download(_URLS["literary"].format(lang=_LANGUAGES[lang]))), Path(dl_manager.download(_URLS["religious"].format(lang=_LANGUAGES[lang])))]
 
         return [
             datasets.SplitGenerator(
@@ -166,4 +164,4 @@ class PalitoDataset(datasets.GeneratorBasedBuilder):
                             },
                         )
 
-                    counter += 1                
+                    counter += 1

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -6,7 +6,8 @@ import datasets
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import (DEFAULT_SEACROWD_VIEW_NAME,
-                                      DEFAULT_SOURCE_VIEW_NAME, Tasks)
+                                      DEFAULT_SOURCE_VIEW_NAME, Licenses,
+                                      Tasks)
 
 _DATASETNAME = "palito"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
@@ -30,7 +31,8 @@ _CITATION = """
 """
 
 # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
-_LANGUAGES = {
+_LANGUAGES = ["bik", "ceb", "hil", "ilo", "tgl", "pam", "pag", "war"]
+_LANG_CONFIG = {
     "bik": "Bikol",
     "ceb": "Cebuano",
     "hil": "Hiligaynon",
@@ -130,7 +132,7 @@ class PalitoDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         lang = self.config.name.split("_")[1]
-        filepaths = [Path(dl_manager.download(_URLS["literary"].format(lang=_LANGUAGES[lang]))), Path(dl_manager.download(_URLS["religious"].format(lang=_LANGUAGES[lang])))]
+        filepaths = [Path(dl_manager.download(_URLS["literary"].format(lang=_LANG_CONFIG[lang]))), Path(dl_manager.download(_URLS["religious"].format(lang=_LANG_CONFIG[lang])))]
 
         return [
             datasets.SplitGenerator(

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -61,7 +61,7 @@ _URLS = {
 }
 
 
-class Palito(datasets.GeneratorBasedBuilder):
+class PalitoDataset(datasets.GeneratorBasedBuilder):
     """Palito corpus"""
 
     subsets = [

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -14,7 +14,20 @@ _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
 _UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
 
 _CITATION = """
-Shirley Dita, Rachel Edita Roxas, Paul Inventado. 2008. Building online corpora of Philippine languages. Proceedings of the 23rd Pacific Asia Conference on Language, Information and Computation. Available online: http://aclweb.org/anthology/Y/Y09/Y09-2024.pdf
+@inproceedings{dita-etal-2009-building,
+    title = "Building Online Corpora of {P}hilippine Languages",
+    author = "Dita, Shirley N.  and
+      Roxas, Rachel Edita O.  and
+      Inventado, Paul",
+    editor = "Kwong, Olivia",
+    booktitle = "Proceedings of the 23rd Pacific Asia Conference on Language, Information and Computation, Volume 2",
+    month = dec,
+    year = "2009",
+    address = "Hong Kong",
+    publisher = "City University of Hong Kong",
+    url = "https://aclanthology.org/Y09-2024",
+    pages = "646--653",
+}
 """
 
 # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)

--- a/seacrowd/sea_datasets/palito/palito.py
+++ b/seacrowd/sea_datasets/palito/palito.py
@@ -59,7 +59,7 @@ of these various forms.
 
 _HOMEPAGE = "https://github.com/imperialite/Philippine-Languages-Online-Corpora/tree/master/PALITO%20Corpus"
 
-_LICENSE = "GNU Lesser General Public License family (lgpl)"
+_LICENSE = Licenses.LGPL.value
 
 _SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
 


### PR DESCRIPTION
Closes #30 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
