### PR TITLE
Closes #94 | Create dataset loader for Filipino Age-of-Acquisition Words

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ soundfile
 torchaudio==0.11
 ffmpeg
 conllu
-openpyxl
+openpyxl==3.1.2
 translate-toolkit==3.7.3
 typing_extensions
 scikit-learn==1.1.2

--- a/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
+++ b/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
@@ -129,9 +129,3 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
                     "text_2_name": "eng",
                 }
             yield index, example
-
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
+++ b/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
@@ -110,7 +110,7 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        filepath, _ = urllib.request.urlretrieve(_URL)
+        filepath = dl_manager.download(_URL)
         return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"filepath": filepath})]
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
@@ -118,13 +118,13 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
         df = pd.read_excel(filepath, index_col=None)
         for index, row in df.iterrows():
             if self.config.schema == "source":
-                example = dict(row)
+                example = row.to_dict()
 
             elif self.config.schema == "seacrowd_t2t":
                 example = {
                     "id": str(index),
                     "text_1": row["word"],
-                    "text_2": row["meaning"].split(","),
+                    "text_2": row["meaning"],
                     "text_1_name": "fil",
                     "text_2_name": "eng",
                 }

--- a/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
+++ b/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import urllib
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -23,7 +22,7 @@ from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import Licenses, Tasks
 
-_CITATION = """\
+_CITATION = """
 @techreport{dulaynag2021filaoa,
   author    = {Dulay, Katrina May and Nag, Somali},
   title     = {TalkTogether Age-of-Acquisition Word Lists for 885 Kannada and Filipino Words},
@@ -55,7 +54,7 @@ _SEACROWD_VERSION = "1.0.0"
 
 
 class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
-    """\
+    """
     Dataset of Filipino words, their English meanings, and their part-of-speech tag
     obtained from an age-of-acquisition study.
     """

--- a/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
+++ b/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+import datasets
+
+from seacrowds.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@techreport{dulay2021talktogether,
+  author    = {Dulay, Katrina May and Nag, Somali},
+  title     = {TalkTogether Age-of-Acquisition Word Lists for 885 Kannada and Filipino Words},
+  institution = {TalkTogether},
+  year      = {2021},
+  type      = {Technical Report},
+  url       = {https://osf.io/gnjmr},
+  doi       = {10.17605/OSF.IO/3ZDFN},
+}
+"""
+
+_LOCAL = False
+_LANGUAGES = ["fil"]
+_DATASETNAME = "filipino_words_aoa"
+_DESCRIPTION = """\
+The dataset contains 885 Filipino words derived from an age-of-acquisition participant study. The words are derived child-directed corpora 
+using pre-specified linguistic criteria. Each word in the corpora contains information about its meaning, part-of-speech (POS), age band, 
+morpheme count, syllable length, phoneme length, and the level of book it was derived from. The dataset can be used for lexical complexity
+prediction, lexical simplification, and readability assessment research.
+"""
+
+_HOMEPAGE = "https://osf.io/3zdfn/"
+_LICENSE = Licenses.CC_BY_SA_4_0.value
+_URL = "https://osf.io/download/j42g7/"
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION, Tasks.POS_TAGGING]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    pos_labels = ["adjective", "adverb", "noun", "pronoun", "verb"]
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    SEACROWD_SCHEMA_NAME = "seq_label"
+    
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "word": datasets.Value("string"),
+                    "meaning": datasets.Value("string"),
+                    "POS_tag": datasets.Value("string"),
+                    "mean_AoA": datasets.Value("float64"),
+                    "mean_AoA_ageband": datasets.Value("string"),
+                    "morpheme_count": datasets.Value("int64"),
+                    "syllable_length": datasets.Value("int64"),
+                    "phoneme_length": datasets.Value("int64"),
+                    "book_ageband": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.seq_label_features(self.pos_labels)
+            
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        filepath = Path(dl_manager.download_and_extract(_URL))
+        return [
+            datasets.SplitGenerator(name=datasets.Split.TRAIN),
+            gen_kwargs={"filepath": filepath}
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        df = pd.read_csv(filepath, index_col=None)
+        if self.config.schema == "source":
+            for index, row in enumerate(df):
+                example = {
+                    "index": str(index),
+                    "tokens": row["word"],
+                    "pos_tags": row["POS_tag"],
+                }
+                yield index, example
+
+        elif self.config.schema == "seacrowd_[seacrowd_schema_name]":
+            for index, row in enumerate(df):
+                example = {
+                    "id": str(index),
+                    "tokens": row["word"],
+                    "labels": row["POS_tag"],
+                }
+                
+                yield index, example
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
+
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
+++ b/seacrowd/sea_datasets/filipino_words_aoa/filipino_words_aoa.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @techreport{dulaynag2021filaoa,
@@ -36,11 +36,11 @@ _CITATION = """\
 """
 
 _LOCAL = False
-_LANGUAGES = ["fil"]
+_LANGUAGES = ["fil", "eng"]
 _DATASETNAME = "filipino_words_aoa"
 _DESCRIPTION = """\
-The dataset contains 885 Filipino words derived from an age-of-acquisition participant study. The words are derived child-directed corpora 
-using pre-specified linguistic criteria. Each word in the corpora contains information about its meaning, part-of-speech (POS), age band, 
+The dataset contains 885 Filipino words derived from an age-of-acquisition participant study. The words are derived child-directed corpora
+using pre-specified linguistic criteria. Each word in the corpora contains information about its meaning, part-of-speech (POS), age band,
 morpheme count, syllable length, phoneme length, and the level of book it was derived from. The dataset can be used for lexical complexity
 prediction, lexical simplification, and readability assessment research.
 """
@@ -53,14 +53,16 @@ _SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
 _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
+
 class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
     """\
     Dataset of Filipino words, their English meanings, and their part-of-speech tag
     obtained from an age-of-acquisition study.
     """
+
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
-    
+
     BUILDER_CONFIGS = [
         SEACrowdConfig(
             name=f"{_DATASETNAME}_source",
@@ -75,7 +77,7 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
             description=f"{_DATASETNAME} SeaCrowd text-to-text schema",
             schema="seacrowd_t2t",
             subset_id=_DATASETNAME,
-        )
+        ),
     ]
 
     DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
@@ -97,7 +99,7 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
             )
         elif self.config.schema == "seacrowd_t2t":
             features = schemas.text2text_features
-            
+
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,
@@ -109,12 +111,7 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         filepath, _ = urllib.request.urlretrieve(_URL)
-        return [
-            datasets.SplitGenerator(
-                name=datasets.Split.TRAIN,
-                gen_kwargs={"filepath": filepath}
-            )
-        ]
+        return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"filepath": filepath})]
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
@@ -132,6 +129,7 @@ class FilipinoWordsAOADataset(datasets.GeneratorBasedBuilder):
                     "text_2_name": "eng",
                 }
             yield index, example
+
 
 # This allows you to run your dataloader with `python [dataset_name].py` during development
 # TODO: Remove this before making your PR


### PR DESCRIPTION
Closes #94 .

### Notes
- Decided not to include the `seq_label` task for the POS tags in the dataset because (a) they don't follow the schema, and (b) in my opinion, it isn't "true" POS-tagging. As a native Filipino speaker, there are some words in the dataset that can vary in POS based on how they're used.
- `dl_manager` isn't used in `_split_generators`. I used `urllib.request.urlretrieve()` and the `openpyxl` package instead.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
