### PR TITLE
Closes #50 | Create dataset loader for TCOPE

### DIFF
--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -166,27 +166,24 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
                 },
             ),
         ]
-
-    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
-
-    # TODO: change the args of this function to match the keys in `gen_kwargs`. You may add any necessary kwargs.
-
+    
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
+        if self.config.schema not in ("source", "seacrowd_seq_label"):
+            raise ValueError(f"Received unexpected config schema {self.config.schema}")
+
         df = pd.read_csv(filepath, index_col=None)
         df = df[df["divided.tweet"].notna()]
         for index, row in df.iterrows():
             if self.config.schema == "source":
                 example = dict(row)
             elif self.config.schema == "seacrowd_seq_label":
-                print(row["postag"])
                 tokens, tags = self.split_token_and_tag(row["postag"], valid_tags=self.pos_labels)
                 example = {
                     "id": str(index),
                     "tokens": tokens,
                     "labels": tags,
                 }
-                print(example)
 
             yield index, example
 

--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -145,7 +145,6 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
                     "tokens": tokens,
                     "labels": tags,
                 }
-
             yield index, example
 
     def split_token_and_tag(self, tweet: str, valid_tags: List[str]) -> Tuple[List[str], List[str]]:
@@ -155,7 +154,9 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
         tags = []
         for indiv_token_with_tag in tokens_with_tags:
             token, tag = indiv_token_with_tag.rsplit("_", 1)
+            tokens.append(token)
             if tag in valid_tags:
-                tokens.append(token)
                 tags.append(tag)
+            else:  # Use "X"/other spaCy tag for invalid POS tags
+                tags.append("X")
         return tokens, tags

--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -1,0 +1,206 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This template serves as a starting point for contributing a dataset to the SEACrowd Datahub repo.
+
+When modifying it for your dataset, look for TODO items that offer specific instructions.
+
+Full documentation on writing dataset loading scripts can be found here:
+https://huggingface.co/docs/datasets/add_dataset.html
+
+To create a dataset loading script you will create a class and implement 3 methods:
+  * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.
+  * `_split_generators`: Downloads and extracts data for each split (e.g. train/val/test) or associate local data with each split.
+  * `_generate_examples`: Creates examples from data on disk that conform to each schema defined in `_info`.
+
+TODO: Before submitting your script, delete this doc string and replace it with a description of your dataset.
+"""
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{gonzales_broadening_2023,
+  author    = {Gonzales, Wilkinson Daniel Wong},
+  title     = {Broadening horizons in the diachronic and sociolinguisstic study of 
+  Philippine Englishes with the Twitter Corpus of Philippine Englishes (TCOPE)},
+  journal   = {English World-Wide},
+  year      = {2023},
+  url       = {https://osf.io/k3qzx},
+  doi       = {10.17605/OSF.IO/3Q5PW},
+}
+"""
+
+_LOCAL = False
+_LANGUAGES = ["eng", "fil"] 
+_DATASETNAME = "tcope"
+_DESCRIPTION = """\
+The TCOPE dataset consists of 1,048,576 public tweets (amounting to about 13.5 million words) collected from 13 major cities from the Philippines.
+Tweets are tagged for part-of-speech and dependency parsing using spaCy.Tweets collected are from 2010 to 2021.
+The publicly available dataset is only a random sample (10%) from the whole TCOPE dataset, which consist of roughly 27 million tweets
+(amounting to about 135 million words) collected from 29 major cities during the same date range.
+"""
+
+_HOMEPAGE = "https://osf.io/3q5pw/wiki/home/"
+_LICENSE = "Licenses.CC0_1_0.value"
+_URL = "https://files.osf.io/v1/resources/3q5pw/providers/osfstorage/63737a5b0e715d3616a998f7"
+
+_SUPPORTED_TASKS = [Tasks.DEPENDENCY_PARSING, Tasks.POS_TAGGING]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
+class TCOPEDataset(datasets.GeneratorBasedBuilder):
+    """TCOPE is a dataset of Philippine English tweets by Gonzales (2023)."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    # Actual data has invalid "labels" likely due to coding errors,
+    # such as "BODY", "BIRTHDAY", "HAVAIANAS", etc. Only valid
+    # POS tags are included here and in loaded data.
+    pos_labels = [
+        "NOUN", "PUNCT", "PROPN", "VERB", "PRON", "ADP",
+        "ADJ", "ADV", "DET", "AUX", "PART", "CCONJ", "INTJ",
+        "SPACE", "SCONJ", "NUM", "X", "SYM"
+    ]
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_kb",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd knowledge base schema",
+            schema="seacrowd_kb",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_seq_label",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd sequence labeling schema",
+            schema="seacrowd_seq_label",
+            subset_id=_DATASETNAME,
+        )
+    ]
+
+    DEFAULT_CONFIG_NAME = "tcope_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
+
+        # You can arbitrarily nest lists and dictionaries.
+        # For iterables, use lists over tuples or `datasets.Sequence`
+
+        if self.config.schema == "source":
+           features = datasets.Features(
+               {
+                   "copeid": datasets.Value("string"),
+                   "userid": datasets.Value("int64"),
+                   "divided.tweet": datasets.Value("string"),
+                   "postag": datasets.Value("string"),
+                   "deptag": datasets.Value("string"),
+                   "citycode": datasets.Value("string"),
+                   "year": datasets.Value("int64"),
+                   "extendedcope": datasets.Value("string"),
+               }
+           )
+
+        elif self.config.schema == "seacrowd_kb":
+            #features = schemas.kb_features
+        
+        elif self.config.schema == "seacrowd_seq_label":
+            features = schemas.seq_label_features(label_names=self.pos_labels)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        # First ZIP contains second ZIP which has spreadsheet data
+        folder_zip_dir = dl_manager.download_and_extract(_URL)
+        spreadsheet_zip_dir = dl_manager.extract(
+            f"{folder_zip_dir}/public_v1/spreadsheet_format.zip"
+        )
+        spreadsheet_fp = f"{spreadsheet_zip_dir}/spreadsheet_format/tcope_v1_public_sample.csv"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": spreadsheet_fp,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+
+    # TODO: change the args of this function to match the keys in `gen_kwargs`. You may add any necessary kwargs.
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        df = pd.read_csv(filepath, index_col=None)
+        if self.config.schema == "source":
+            # TODO: yield (key, example) tuples in the original dataset schema
+            #for key, example in thing:
+                #yield key, example
+
+        elif self.config.schema == "seacrowd_seq_label":
+            # TODO: yield (key, example) tuples in the seacrowd schema
+            for key, example in thing:
+                yield key, example
+
+    def split_token_and_tag(self, tweet: str, valid_tags: List[str]) -> Tuple[List[str], List[str]]:
+        tokens_with_tags = tweet.split()
+
+        tokens = []
+        tags = []
+        for indiv_token_with_tag in tokens_with_tags:
+            token, tag = indiv_token_with_tag.split("_")
+            if tag in valid_tags:
+                tokens.append(token)
+                tags.append(tags)
+        return tokens, tags
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
+
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -12,23 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-This template serves as a starting point for contributing a dataset to the SEACrowd Datahub repo.
-
-When modifying it for your dataset, look for TODO items that offer specific instructions.
-
-Full documentation on writing dataset loading scripts can be found here:
-https://huggingface.co/docs/datasets/add_dataset.html
-
-To create a dataset loading script you will create a class and implement 3 methods:
-  * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.
-  * `_split_generators`: Downloads and extracts data for each split (e.g. train/val/test) or associate local data with each split.
-  * `_generate_examples`: Creates examples from data on disk that conform to each schema defined in `_info`.
-
-TODO: Before submitting your script, delete this doc string and replace it with a description of your dataset.
-"""
-import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -37,13 +20,12 @@ import pandas as pd
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
-# TODO: Add BibTeX citation
-_CITATION = """\
+_CITATION = """
 @article{gonzales_broadening_2023,
   author    = {Gonzales, Wilkinson Daniel Wong},
-  title     = {Broadening horizons in the diachronic and sociolinguisstic study of 
+  title     = {Broadening horizons in the diachronic and sociolinguisstic study of
   Philippine Englishes with the Twitter Corpus of Philippine Englishes (TCOPE)},
   journal   = {English World-Wide},
   year      = {2023},
@@ -53,25 +35,24 @@ _CITATION = """\
 """
 
 _LOCAL = False
-_LANGUAGES = ["eng", "fil"] 
+_LANGUAGES = ["eng", "fil"]
 _DATASETNAME = "tcope"
-_DESCRIPTION = """\
+_DESCRIPTION = """
 The TCOPE dataset consists of 1,048,576 public tweets (amounting to about 13.5 million words) collected from 13 major cities from the Philippines.
-Tweets are tagged for part-of-speech and dependency parsing using spaCy.Tweets collected are from 2010 to 2021.
+Tweets are tagged for part-of-speech and dependency parsing using spaCy. Tweets collected are from 2010 to 2021.
 The publicly available dataset is only a random sample (10%) from the whole TCOPE dataset, which consist of roughly 27 million tweets
 (amounting to about 135 million words) collected from 29 major cities during the same date range.
 """
 
 _HOMEPAGE = "https://osf.io/3q5pw/wiki/home/"
-_LICENSE = "Licenses.CC0_1_0.value"
+_LICENSE = Licenses.CC0_1_0.value
 _URL = "https://files.osf.io/v1/resources/3q5pw/providers/osfstorage/63737a5b0e715d3616a998f7"
 
-_SUPPORTED_TASKS = [Tasks.DEPENDENCY_PARSING, Tasks.POS_TAGGING]
+_SUPPORTED_TASKS = [Tasks.POS_TAGGING]
 _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
 class TCOPEDataset(datasets.GeneratorBasedBuilder):
     """TCOPE is a dataset of Philippine English tweets by Gonzales (2023)."""
 
@@ -81,11 +62,7 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
     # Actual data has invalid "labels" likely due to coding errors,
     # such as "BODY", "BIRTHDAY", "HAVAIANAS", etc. Only valid
     # POS tags are included here and in loaded data.
-    pos_labels = [
-        "NOUN", "PUNCT", "PROPN", "VERB", "PRON", "ADP",
-        "ADJ", "ADV", "DET", "AUX", "PART", "CCONJ", "INTJ",
-        "SPACE", "SCONJ", "NUM", "X", "SYM"
-    ]
+    pos_labels = ["NOUN", "PUNCT", "PROPN", "VERB", "PRON", "ADP", "ADJ", "ADV", "DET", "AUX", "PART", "CCONJ", "INTJ", "SPACE", "SCONJ", "NUM", "X", "SYM"]
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
@@ -96,47 +73,31 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
             subset_id=_DATASETNAME,
         ),
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_seacrowd_kb",
-            version=SEACROWD_VERSION,
-            description=f"{_DATASETNAME} SEACrowd knowledge base schema",
-            schema="seacrowd_kb",
-            subset_id=_DATASETNAME,
-        ),
-        SEACrowdConfig(
             name=f"{_DATASETNAME}_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description=f"{_DATASETNAME} SEACrowd sequence labeling schema",
             schema="seacrowd_seq_label",
             subset_id=_DATASETNAME,
-        )
+        ),
     ]
 
     DEFAULT_CONFIG_NAME = "tcope_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
-        # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
-
-        # You can arbitrarily nest lists and dictionaries.
-        # For iterables, use lists over tuples or `datasets.Sequence`
-
         if self.config.schema == "source":
-           features = datasets.Features(
-               {
-                   "copeid": datasets.Value("string"),
-                   "userid": datasets.Value("int64"),
-                   "divided.tweet": datasets.Value("string"),
-                   "postag": datasets.Value("string"),
-                   "deptag": datasets.Value("string"),
-                   "citycode": datasets.Value("string"),
-                   "year": datasets.Value("int64"),
-                   "extendedcope": datasets.Value("string"),
-               }
-           )
+            features = datasets.Features(
+                {
+                    "copeid": datasets.Value("string"),
+                    "userid": datasets.Value("int64"),
+                    "divided.tweet": datasets.Value("string"),
+                    "postag": datasets.Value("string"),
+                    "deptag": datasets.Value("string"),
+                    "citycode": datasets.Value("string"),
+                    "year": datasets.Value("int64"),
+                    "extendedcope": datasets.Value("string"),
+                }
+            )
 
-        elif self.config.schema == "seacrowd_kb":
-            pass
-        
         elif self.config.schema == "seacrowd_seq_label":
             features = schemas.seq_label_features(label_names=self.pos_labels)
 
@@ -150,11 +111,10 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        # First ZIP contains second ZIP which has spreadsheet data
+        # First ZIP contains second ZIP
+        # Second ZIP has spreadsheet data
         folder_zip_dir = dl_manager.download_and_extract(_URL)
-        spreadsheet_zip_dir = dl_manager.extract(
-            f"{folder_zip_dir}/public_v1/spreadsheet_format.zip"
-        )
+        spreadsheet_zip_dir = dl_manager.extract(f"{folder_zip_dir}/public_v1/spreadsheet_format.zip")
         spreadsheet_fp = f"{spreadsheet_zip_dir}/spreadsheet_format/tcope_v1_public_sample.csv"
 
         return [
@@ -166,7 +126,7 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
                 },
             ),
         ]
-    
+
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         if self.config.schema not in ("source", "seacrowd_seq_label"):
@@ -176,7 +136,7 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
         df = df[df["divided.tweet"].notna()]
         for index, row in df.iterrows():
             if self.config.schema == "source":
-                example = dict(row)
+                example = row.to_dict()
             elif self.config.schema == "seacrowd_seq_label":
                 tokens, tags = self.split_token_and_tag(row["postag"], valid_tags=self.pos_labels)
                 example = {
@@ -198,12 +158,3 @@ class TCOPEDataset(datasets.GeneratorBasedBuilder):
                 tokens.append(token)
                 tags.append(tag)
         return tokens, tags
-
-# This template is based on the following template from the datasets package:
-# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
-
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -39,6 +39,7 @@ _LANGUAGES = ["eng", "fil"]
 _DATASETNAME = "tcope"
 _DESCRIPTION = """
 The TCOPE dataset consists of 1,048,576 public tweets (amounting to about 13.5 million words) collected from 13 major cities from the Philippines.
+Tweets are either purely in English or involve code-switching between English and Filipino.
 Tweets are tagged for part-of-speech and dependency parsing using spaCy. Tweets collected are from 2010 to 2021.
 The publicly available dataset is only a random sample (10%) from the whole TCOPE dataset, which consist of roughly 27 million tweets
 (amounting to about 135 million words) collected from 29 major cities during the same date range.

--- a/seacrowd/sea_datasets/tcope/tcope.py
+++ b/seacrowd/sea_datasets/tcope/tcope.py
@@ -38,7 +38,7 @@ _LOCAL = False
 _LANGUAGES = ["eng", "fil"]
 _DATASETNAME = "tcope"
 _DESCRIPTION = """
-The TCOPE dataset consists of 1,048,576 public tweets (amounting to about 13.5 million words) collected from 13 major cities from the Philippines.
+The TCOPE dataset consists of public tweets (amounting to about 13.5 million words) collected from 13 major cities from the Philippines.
 Tweets are either purely in English or involve code-switching between English and Filipino.
 Tweets are tagged for part-of-speech and dependency parsing using spaCy. Tweets collected are from 2010 to 2021.
 The publicly available dataset is only a random sample (10%) from the whole TCOPE dataset, which consist of roughly 27 million tweets
@@ -49,7 +49,7 @@ _HOMEPAGE = "https://osf.io/3q5pw/wiki/home/"
 _LICENSE = Licenses.CC0_1_0.value
 _URL = "https://files.osf.io/v1/resources/3q5pw/providers/osfstorage/63737a5b0e715d3616a998f7"
 
-_SUPPORTED_TASKS = [Tasks.POS_TAGGING]
+_SUPPORTED_TASKS = [Tasks.POS_TAGGING, Tasks.DEPENDENCY_PARSING]
 _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 


### PR DESCRIPTION
Closes #50.

### Notes
- Decided not to implement schema for dependency parsing task. Corpus has dependency-parsed text but no information on grammatical relationships between words. Essentially it's similar to just sequence labeling. Let me know if we can still implement this task in another way though.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
