### PR TITLE
Closes #208 | Implement dataloaders for UIT_VSFC

### DIFF
--- a/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
+++ b/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
@@ -201,7 +201,3 @@ class UITVSFCDataset(datasets.GeneratorBasedBuilder):
                         "text": sentence.strip(),
                         "label": int(topic.strip()),
                     }
-
-
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
+++ b/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
@@ -134,7 +134,7 @@ class UITVSFC(datasets.GeneratorBasedBuilder):
             )
         elif self.config.name == f"{_DATASETNAME}_sentiment_seacrowd_{self.SEACROWD_SCHEMA_NAME}":
             features = schemas.text_features(self.SENTIMENT_LABEL_CLASSES)
-        elif self.config.name == f"{_DATASETNAME}_topicseacrowd_{self.SEACROWD_SCHEMA_NAME}":
+        elif self.config.name == f"{_DATASETNAME}_topic_seacrowd_{self.SEACROWD_SCHEMA_NAME}":
             features = schemas.text_features(self.TOPIC_LABEL_CLASSES)
 
         return datasets.DatasetInfo(

--- a/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
+++ b/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -38,8 +37,8 @@ _CITATION = """\
 _DATASETNAME = "uit_vsfc"
 
 _DESCRIPTION = """\
-This corpus consists of student feedback obtained from end-of-semester surveys at a Vietnamese university. 
-Feedback is classified into four possible topics: lecturer, curriculum, facility or others. 
+This corpus consists of student feedback obtained from end-of-semester surveys at a Vietnamese university.
+Feedback is classified into four possible topics: lecturer, curriculum, facility or others.
 Feedback is also labeled as one of three sentiment polarities: positive, negative or neutral.
 """
 
@@ -55,7 +54,7 @@ _LOCAL = False
 _URLS = {
     "train": {
         "sentences": "https://drive.google.com/uc?id=1nzak5OkrheRV1ltOGCXkT671bmjODLhP&export=download",
-        "sentiments": "https://drive.google.com/uc?id=1ye-gOZIBqXdKOoi_YxvpT6FeRNmViPPv&export=down load",
+        "sentiments": "https://drive.google.com/uc?id=1ye-gOZIBqXdKOoi_YxvpT6FeRNmViPPv&export=download",
         "topics": "https://drive.google.com/uc?id=14MuDtwMnNOcr4z_8KdpxprjbwaQ7lJ_C&export=download",
     },
     "validation": {
@@ -77,7 +76,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class UITVSFC(datasets.GeneratorBasedBuilder):
+class UITVSFCDataset(datasets.GeneratorBasedBuilder):
     """This corpus consists of student feedback obtained from end-of-semester surveys at a Vietnamese university.
     Feedback is classified into four possible topics: lecturer, curriculum, facility or others.
     Feedback is also labeled as one of three sentiment polarities: positive, negative or neutral."""
@@ -151,7 +150,6 @@ class UITVSFC(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                # Whatever you put in gen_kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "sentences_path": data_dir["train"]["sentences"],
                     "sentiments_path": data_dir["train"]["sentiments"],
@@ -181,11 +179,6 @@ class UITVSFC(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, sentences_path: Path, sentiments_path: Path, topics_path: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
-        # TODO: This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
-
-        # The `key` is for legacy reasons (tfds) and is not important in itself, but must be unique for each example.
-
-        # NOTE: For local datasets you will have access to self.config.data_dir and self.config.data_files
 
         if self.config.schema == "source":
             with open(sentences_path, encoding="utf-8") as sentences, open(sentiments_path, encoding="utf-8") as sentiments, open(topics_path, encoding="utf-8") as topics:
@@ -210,11 +203,5 @@ class UITVSFC(datasets.GeneratorBasedBuilder):
                     }
 
 
-# This template is based on the following template from the datasets package:
-# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
-
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
 if __name__ == "__main__":
     datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
+++ b/seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py
@@ -1,0 +1,220 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@inproceedings{van2018uit,
+  title={UIT-VSFC: Vietnamese students’ feedback corpus for sentiment analysis},
+  author={Van Nguyen, Kiet and Nguyen, Vu Duc and Nguyen, Phu XV and Truong, Tham TH and Nguyen, Ngan Luu-Thuy},
+  booktitle={2018 10th international conference on knowledge and systems engineering (KSE)},
+  pages={19--24},
+  year={2018},
+  organization={IEEE}
+}
+"""
+
+
+_DATASETNAME = "uit_vsfc"
+
+_DESCRIPTION = """\
+This corpus consists of student feedback obtained from end-of-semester surveys at a Vietnamese university. 
+Feedback is classified into four possible topics: lecturer, curriculum, facility or others. 
+Feedback is also labeled as one of three sentiment polarities: positive, negative or neutral.
+"""
+
+_HOMEPAGE = "https://drive.google.com/drive/folders/1HooABJyrddVGzll7fgkJ6VzkG_XuWfRu"
+
+_LANGUAGES = ["vie"]
+
+_LICENSE = Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+
+_URLS = {
+    "train": {
+        "sentences": "https://drive.google.com/uc?id=1nzak5OkrheRV1ltOGCXkT671bmjODLhP&export=download",
+        "sentiments": "https://drive.google.com/uc?id=1ye-gOZIBqXdKOoi_YxvpT6FeRNmViPPv&export=down load",
+        "topics": "https://drive.google.com/uc?id=14MuDtwMnNOcr4z_8KdpxprjbwaQ7lJ_C&export=download",
+    },
+    "validation": {
+        "sentences": "https://drive.google.com/uc?id=1sMJSR3oRfPc3fe1gK-V3W5F24tov_517&export=download",
+        "sentiments": "https://drive.google.com/uc?id=1GiY1AOp41dLXIIkgES4422AuDwmbUseL&export=download",
+        "topics": "https://drive.google.com/uc?id=1DwLgDEaFWQe8mOd7EpF-xqMEbDLfdT-W&export=download",
+    },
+    "test": {
+        "sentences": "https://drive.google.com/uc?id=1aNMOeZZbNwSRkjyCWAGtNCMa3YrshR-n&export=download",
+        "sentiments": "https://drive.google.com/uc?id=1vkQS5gI0is4ACU58-AbWusnemw7KZNfO&export=download",
+        "topics": "https://drive.google.com/uc?id=1_ArMpDguVsbUGl-xSMkTF_p5KpZrmpSB&export=download",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS, Tasks.TOPIC_MODELING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class UITVSFC(datasets.GeneratorBasedBuilder):
+    """This corpus consists of student feedback obtained from end-of-semester surveys at a Vietnamese university.
+    Feedback is classified into four possible topics: lecturer, curriculum, facility or others.
+    Feedback is also labeled as one of three sentiment polarities: positive, negative or neutral."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    SENTIMENT_LABEL_CLASSES = ["positive", "negative", "neutral"]
+    TOPIC_LABEL_CLASSES = ["lecturer", "training_program", "others", "facility"]
+
+    SEACROWD_SCHEMA_NAME = "text"
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_sentiment_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_topic_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_sentiment_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_topic_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "sentence": datasets.Value("string"),
+                    "sentiment": datasets.ClassLabel(names=self.SENTIMENT_LABEL_CLASSES),
+                    "topic": datasets.ClassLabel(names=self.TOPIC_LABEL_CLASSES),
+                }
+            )
+        elif self.config.name == f"{_DATASETNAME}_sentiment_seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text_features(self.SENTIMENT_LABEL_CLASSES)
+        elif self.config.name == f"{_DATASETNAME}_topicseacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text_features(self.TOPIC_LABEL_CLASSES)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        data_dir = dl_manager.download(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "sentences_path": data_dir["train"]["sentences"],
+                    "sentiments_path": data_dir["train"]["sentiments"],
+                    "topics_path": data_dir["train"]["topics"],
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "sentences_path": data_dir["test"]["sentences"],
+                    "sentiments_path": data_dir["test"]["sentiments"],
+                    "topics_path": data_dir["test"]["topics"],
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "sentences_path": data_dir["validation"]["sentences"],
+                    "sentiments_path": data_dir["validation"]["sentiments"],
+                    "topics_path": data_dir["validation"]["topics"],
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, sentences_path: Path, sentiments_path: Path, topics_path: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # TODO: This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+
+        # The `key` is for legacy reasons (tfds) and is not important in itself, but must be unique for each example.
+
+        # NOTE: For local datasets you will have access to self.config.data_dir and self.config.data_files
+
+        if self.config.schema == "source":
+            with open(sentences_path, encoding="utf-8") as sentences, open(sentiments_path, encoding="utf-8") as sentiments, open(topics_path, encoding="utf-8") as topics:
+                for key, (sentence, sentiment, topic) in enumerate(zip(sentences, sentiments, topics)):
+                    yield key, {
+                        "sentence": sentence.strip(),
+                        "sentiment": int(sentiment.strip()),
+                        "topic": int(topic.strip()),
+                    }
+
+        elif self.config.name == f"{_DATASETNAME}_sentiment_seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            with open(sentences_path, encoding="utf-8") as sentences, open(sentiments_path, encoding="utf-8") as sentiments:
+                for key, (sentence, sentiment) in enumerate(zip(sentences, sentiments)):
+                    yield key, {"id": str(key), "text": sentence.strip(), "label": int(sentiment.strip())}
+        elif self.config.name == f"{_DATASETNAME}_topic_seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            with open(sentences_path, encoding="utf-8") as sentences, open(topics_path, encoding="utf-8") as topics:
+                for key, (sentence, topic) in enumerate(zip(sentences, topics)):
+                    yield key, {
+                        "id": str(key),
+                        "text": sentence.strip(),
+                        "label": int(topic.strip()),
+                    }
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
+
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)


### PR DESCRIPTION
Closes #208. 

Note that since this dataset supports both topic modeling and sentiment analysis, they both fall into the schema of General Text Classification. During unit testing, please run the command:
`
python -m tests.test_seacrowd seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py --subset_id uit_vsfc_sentiment
`
for sentiment analysis and:
`
python -m tests.test_seacrowd seacrowd/sea_datasets/uit_vsfc/uit_vsfc.py --subset_id uit_vsfc_topic
`
for topic modeling.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
