### PR TITLE
Closes #163 | Add Bloom-Speech Dataloader

### DIFF
--- a/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
+++ b/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
@@ -1,0 +1,180 @@
+"""
+SEA Crowd Data Loader for Bloom Speech.
+"""
+from typing import Dict, List, Tuple
+
+import datasets
+from datasets.download.download_manager import DownloadManager
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = r"""
+@inproceedings{leong-etal-2022-bloom,
+    title = "Bloom Library: Multimodal Datasets in 300+ Languages for a Variety of Downstream Tasks",
+    author = "Leong, Colin  and
+      Nemecek, Joshua  and
+      Mansdorfer, Jacob  and
+      Filighera, Anna  and
+      Owodunni, Abraham  and
+      Whitenack, Daniel",
+    editor = "Goldberg, Yoav  and
+      Kozareva, Zornitsa  and
+      Zhang, Yue",
+    booktitle = "Proceedings of the 2022 Conference on Empirical Methods in Natural Language Processing",
+    month = dec,
+    year = "2022",
+    address = "Abu Dhabi, United Arab Emirates",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.emnlp-main.590",
+    doi = "10.18653/v1/2022.emnlp-main.590",
+    pages = "8608--8621",
+    abstract = "We present Bloom Library, a linguistically diverse set of multimodal and multilingual datasets for language modeling, image captioning, visual storytelling, and speech synthesis/recognition. These datasets represent either the most, or among the most, multilingual datasets for each of the included downstream tasks. In total, the initial release of the Bloom Library datasets covers 363 languages across 32 language families. We train downstream task models for various languages represented in the data, showing the viability of the data for future work in low-resource, multimodal NLP and establishing the first known baselines for these downstream tasks in certain languages (e.g., Bisu [bzi], with an estimated population of 700 users). Some of these first-of-their-kind baselines are comparable to state-of-the-art performance for higher-resourced languages. The Bloom Library datasets are released under Creative Commons licenses on the Hugging Face datasets hub to catalyze more linguistically diverse research in the included downstream tasks.",
+}
+"""
+
+logger = datasets.logging.get_logger(__name__)
+
+# this config is created for SEACrowd Dataloader
+_LANG_CONFIG = {
+    "bjn": "Banjar",
+    "bzi": "Bisu",
+    "ceb": "Cebuano",
+    "ind": "Indonesian",
+    "jra": "Jarai",
+    "kqr": "Kimaragang",
+    "mya": "Burmese",
+    "tgl": "Tagalog"
+}
+
+#it's a gated dataset, hence _LOCAL = True
+_LOCAL = True
+_LANGUAGES = list(_LANG_CONFIG.keys())
+
+
+_DATASETNAME = "bloom_speech"
+_DESCRIPTION = r"""
+This version of the Bloom Library data is developed specifically for the automatic speech recognition and speech-to-text tasks.
+It includes data from 56 languages across 18 language families. 8 languages are spoken in Southeast Asia
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/sil-ai/bloom-speech"
+_LICENSE = Licenses.CC.value
+
+_URL = "https://huggingface.co/datasets/sil-ai/bloom-speech"
+_HF_REMOTE_REF = "/".join(_URL.split("/")[-2:])
+
+_SUPPORTED_TASKS = [Tasks.SPEECH_RECOGNITION]
+_SOURCE_VERSION = "0.0.1"
+_SEACROWD_VERSION = "1.0.0"
+
+CONFIG_SUFFIXES_FOR_TASK = [TASK_TO_SCHEMA.get(task).lower() for task in _SUPPORTED_TASKS]
+
+
+def construct_configs_on_langs(languages: list = None) -> List[SEACrowdConfig]:
+    """
+    The function `construct_configs` constructs a list of SEACrowdConfig objects based on the provided
+    languages or a default language, and returns the list.
+
+    input:
+        languages (list, default None): The `languages` parameter is a list that specifies the languages for which the
+        configurations need to be constructed. If no languages are provided (value=None), the first value in language config
+        will be used.
+    output:
+        a list of `SEACrowdConfig` objects based on instantiated init variables
+    """
+
+    # set output var
+    config_list = []
+
+    # construct zipped arg for config instantiation
+    TASKS_AND_CONFIG_SUFFIX_PAIRS = list(zip(_SUPPORTED_TASKS, CONFIG_SUFFIXES_FOR_TASK))
+
+    # implement source schema
+    version, config_name_prefix = _SOURCE_VERSION, "source"
+    config_list += [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{_LANG}_{config_name_prefix}",
+            version=datasets.Version(version),
+            description=f"{_DATASETNAME} {config_name_prefix} schema for language code {_LANG}",
+            schema=f"{config_name_prefix}",
+            subset_id=_LANG,
+        )
+        for _LANG in languages
+    ]
+
+    # implement SEACrowd schema
+    version, config_name_prefix = _SEACROWD_VERSION, "seacrowd"
+    for task_obj, config_name_suffix in TASKS_AND_CONFIG_SUFFIX_PAIRS:
+        config_list += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{_LANG}_{config_name_prefix}_{config_name_suffix}",
+                version=datasets.Version(version),
+                description=f"{_DATASETNAME} {config_name_prefix} schema for {task_obj.name} and language code {_LANG}",
+                schema=f"{config_name_prefix}_{config_name_suffix}",
+                subset_id=_LANG,
+            )
+            for _LANG in languages
+        ]
+    return config_list
+
+
+class BloomSpeechDataset(datasets.GeneratorBasedBuilder):
+    """Bloom Speech dataset, subsetted from https://huggingface.co/datasets/sil-ai/bloom-speech"""
+
+    # get all schema w/o lang arg + get all schema w/ lang arg
+    BUILDER_CONFIGS = construct_configs_on_langs(_LANGUAGES)
+
+    def _info(self) -> datasets.DatasetInfo:
+        _config_schema_name = self.config.schema
+        logger.info(f"Received schema name: {self.config.schema}")
+        # source schema
+        if _config_schema_name == "source":
+            features = datasets.Features({
+                "file": datasets.Value("string"),
+                "audio": datasets.Audio(sampling_rate=16_000),
+                "text": datasets.Value("string"),
+                "book": datasets.Value("string"),
+                "instance": datasets.Value("string"),
+                "license": datasets.Value("string"),
+                "credits": datasets.Value("string"),
+                "original_lang_tag": datasets.Value("string"),
+            })
+
+        # speech-text schema
+        elif _config_schema_name == "seacrowd_sptext":
+            features = schemas.speech_text_features
+
+        else:
+            raise ValueError(f"Received unexpected config schema of {_config_schema_name}!")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: DownloadManager) -> List[datasets.SplitGenerator]:
+        hf_dset_dict = datasets.load_dataset(_HF_REMOTE_REF, self.config.subset_id)
+
+        return [datasets.SplitGenerator(name=datasets.Split(dset_key), gen_kwargs={"hf_dset": dset}) for dset_key, dset in hf_dset_dict.items() if dset.num_rows > 0]
+
+    def _generate_examples(self, hf_dset) -> Tuple[int, Dict]:
+        _config_schema_name = self.config.schema
+
+        _idx = 0
+        for datapoints in hf_dset:
+            # since no _idx is available to be used, we're creating it manually for both schema
+            if _config_schema_name == "source":
+                yield _idx, {colname: datapoints[colname] for colname in self.info.features}
+
+            elif _config_schema_name == "seacrowd_sptext":
+                yield _idx, {"id": _idx, "path": datapoints["file"], "audio": datapoints["audio"], "text": datapoints["text"], "speaker_id": None, "metadata": {"speaker_age": None, "speaker_gender": None}}
+
+            else:
+                raise ValueError(f"Received unexpected config schema of {_config_schema_name}!")
+
+            _idx += 1

--- a/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
+++ b/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
@@ -30,7 +30,6 @@ _CITATION = r"""
     url = "https://aclanthology.org/2022.emnlp-main.590",
     doi = "10.18653/v1/2022.emnlp-main.590",
     pages = "8608--8621",
-    abstract = "We present Bloom Library, a linguistically diverse set of multimodal and multilingual datasets for language modeling, image captioning, visual storytelling, and speech synthesis/recognition. These datasets represent either the most, or among the most, multilingual datasets for each of the included downstream tasks. In total, the initial release of the Bloom Library datasets covers 363 languages across 32 language families. We train downstream task models for various languages represented in the data, showing the viability of the data for future work in low-resource, multimodal NLP and establishing the first known baselines for these downstream tasks in certain languages (e.g., Bisu [bzi], with an estimated population of 700 users). Some of these first-of-their-kind baselines are comparable to state-of-the-art performance for higher-resourced languages. The Bloom Library datasets are released under Creative Commons licenses on the Hugging Face datasets hub to catalyze more linguistically diverse research in the included downstream tasks.",
 }
 """
 
@@ -39,15 +38,15 @@ logger = datasets.logging.get_logger(__name__)
 # this config is created for SEACrowd Dataloader
 _LANG_CONFIG = {"bjn": "Banjar", "bzi": "Bisu", "ceb": "Cebuano", "ind": "Indonesian", "jra": "Jarai", "kqr": "Kimaragang", "mya": "Burmese", "tgl": "Tagalog"}
 
-# it's a gated dataset, hence _LOCAL = True
-_LOCAL = True
+_LOCAL = False
 _LANGUAGES = list(_LANG_CONFIG.keys())
 
 
 _DATASETNAME = "bloom_speech"
 _DESCRIPTION = r"""
 This version of the Bloom Library data is developed specifically for the automatic speech recognition and speech-to-text tasks.
-It includes data from 56 languages across 18 language families. 8 languages are spoken in Southeast Asia
+It includes data from 56 languages across 18 language families. 8 languages are spoken in Southeast Asia.
+Before using this dataloader, please accept the acknowledgement at https://huggingface.co/datasets/sil-ai/bloom-captioning and use huggingface-cli login for authentication.
 """
 
 _HOMEPAGE = "https://huggingface.co/datasets/sil-ai/bloom-speech"

--- a/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
+++ b/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
@@ -37,18 +37,9 @@ _CITATION = r"""
 logger = datasets.logging.get_logger(__name__)
 
 # this config is created for SEACrowd Dataloader
-_LANG_CONFIG = {
-    "bjn": "Banjar",
-    "bzi": "Bisu",
-    "ceb": "Cebuano",
-    "ind": "Indonesian",
-    "jra": "Jarai",
-    "kqr": "Kimaragang",
-    "mya": "Burmese",
-    "tgl": "Tagalog"
-}
+_LANG_CONFIG = {"bjn": "Banjar", "bzi": "Bisu", "ceb": "Cebuano", "ind": "Indonesian", "jra": "Jarai", "kqr": "Kimaragang", "mya": "Burmese", "tgl": "Tagalog"}
 
-#it's a gated dataset, hence _LOCAL = True
+# it's a gated dataset, hence _LOCAL = True
 _LOCAL = True
 _LANGUAGES = list(_LANG_CONFIG.keys())
 
@@ -131,16 +122,18 @@ class BloomSpeechDataset(datasets.GeneratorBasedBuilder):
         logger.info(f"Received schema name: {self.config.schema}")
         # source schema
         if _config_schema_name == "source":
-            features = datasets.Features({
-                "file": datasets.Value("string"),
-                "audio": datasets.Audio(sampling_rate=16_000),
-                "text": datasets.Value("string"),
-                "book": datasets.Value("string"),
-                "instance": datasets.Value("string"),
-                "license": datasets.Value("string"),
-                "credits": datasets.Value("string"),
-                "original_lang_tag": datasets.Value("string"),
-            })
+            features = datasets.Features(
+                {
+                    "file": datasets.Value("string"),
+                    "audio": datasets.Audio(sampling_rate=16_000),
+                    "text": datasets.Value("string"),
+                    "book": datasets.Value("string"),
+                    "instance": datasets.Value("string"),
+                    "license": datasets.Value("string"),
+                    "credits": datasets.Value("string"),
+                    "original_lang_tag": datasets.Value("string"),
+                }
+            )
 
         # speech-text schema
         elif _config_schema_name == "seacrowd_sptext":

--- a/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
+++ b/seacrowd/sea_datasets/bloom_speech/bloom_speech.py
@@ -46,7 +46,7 @@ _DATASETNAME = "bloom_speech"
 _DESCRIPTION = r"""
 This version of the Bloom Library data is developed specifically for the automatic speech recognition and speech-to-text tasks.
 It includes data from 56 languages across 18 language families. 8 languages are spoken in Southeast Asia.
-Before using this dataloader, please accept the acknowledgement at https://huggingface.co/datasets/sil-ai/bloom-captioning and use huggingface-cli login for authentication.
+Before using this dataloader, please accept the acknowledgement at https://huggingface.co/datasets/sil-ai/bloom-speech and use huggingface-cli login for authentication.
 """
 
 _HOMEPAGE = "https://huggingface.co/datasets/sil-ai/bloom-speech"


### PR DESCRIPTION
Closes #163.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.