### PR TITLE
Closes #216 |  Create dataset loader for Mozilla Pontoon

### DIFF
--- a/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
+++ b/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
@@ -155,7 +155,7 @@ class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
 
         index = 0
         for lang, lang_subset in zip(languages, pontoon_datasets):
-            for _, row in enumerate(lang_subset):
+            for row in lang_subset:
                 if self.config.schema == "source":
                     example = row
 

--- a/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
+++ b/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
@@ -64,20 +64,20 @@ class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
     # Config to load individual datasets per language
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_{lang}_source",
+            name=f"{_DATASETNAME}_eng_{lang}_source",
             version=datasets.Version(_SOURCE_VERSION),
             description=f"{_DATASETNAME} source schema for {lang} language",
             schema="source",
-            subset_id=lang,
+            subset_id=f"{_DATASETNAME}_eng_{lang}",
         )
         for lang in _LANGUAGES
     ] + [
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_{lang}_seacrowd_t2t",
+            name=f"{_DATASETNAME}_eng_{lang}_seacrowd_t2t",
             version=datasets.Version(_SEACROWD_VERSION),
             description=f"{_DATASETNAME} SEACrowd schema for {lang} language",
             schema="seacrowd_t2t",
-            subset_id=lang,
+            subset_id=f"{_DATASETNAME}_eng_{lang}",
         )
         for lang in _LANGUAGES
     ]
@@ -108,8 +108,8 @@ class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source":
             features = datasets.Features(
                 {
-                    "source_sentence": datasets.Value("string"),
-                    "target_sentence": datasets.Value("string"),
+                    "source_string": datasets.Value("string"),
+                    "target_string": datasets.Value("string"),
                 }
             )
         elif self.config.schema == "seacrowd_t2t":
@@ -137,14 +137,14 @@ class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
         """Load dataset from HuggingFace."""
         hf_lang_code = self.LANG_CODE_MAPPER[language]
         hf_remote_ref = "/".join(_URL.split("/")[-2:])
-        return datasets.load_dataset(hf_remote_ref, f"{hf_lang_code}-en", split="train")
+        return datasets.load_dataset(hf_remote_ref, f"en-{hf_lang_code}", split="train")
 
     def _generate_examples(self, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         languages = []
         pontoon_datasets = []
 
-        lang = self.config.name.split("_")[2]
+        lang = self.config.subset_id.split("_")[-1]
         if lang in _LANGUAGES:
             languages.append(lang)
             pontoon_datasets.append(self._load_hf_data_from_remote(lang))
@@ -162,8 +162,8 @@ class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
                 elif self.config.schema == "seacrowd_t2t":
                     example = {
                         "id": str(index),
-                        "text_1": row["source_sentence"],
-                        "text_2": row["target_sentence"],
+                        "text_1": row["source_string"],
+                        "text_2": row["target_string"],
                         "text_1_name": "eng",
                         "text_2_name": lang,
                     }

--- a/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
+++ b/seacrowd/sea_datasets/mozilla_pontoon/mozilla_pontoon.py
@@ -1,0 +1,242 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This template serves as a starting point for contributing a dataset to the SEACrowd Datahub repo.
+
+When modifying it for your dataset, look for TODO items that offer specific instructions.
+
+Full documentation on writing dataset loading scripts can be found here:
+https://huggingface.co/docs/datasets/add_dataset.html
+
+To create a dataset loading script you will create a class and implement 3 methods:
+  * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.
+  * `_split_generators`: Downloads and extracts data for each split (e.g. train/val/test) or associate local data with each split.
+  * `_generate_examples`: Creates examples from data on disk that conform to each schema defined in `_info`.
+
+TODO: Before submitting your script, delete this doc string and replace it with a description of your dataset.
+"""
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{,
+  author    = {},
+  title     = {},
+  journal   = {},
+  volume    = {},
+  year      = {},
+  url       = {},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_LOCAL = False
+_LANGUAGES = [
+    "eng",
+    "mya",
+    "ceb",
+    "gor",
+    "hil",
+    "ilo",
+    "ind",
+    "jav",
+    "khm",
+    "lao",
+    "zlm",
+    "nia",
+    "tgl",
+    "tha",
+    "vie"
+]
+_DATASETNAME = "mozilla_pontoon"
+_DESCRIPTION = """
+This dataset contains translations from Mozilla's Pontoon localization platform
+for more than 200 languages. Source sentences are in English.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/ayymen/Pontoon-Translations"
+_LICENSE = Licenses.BSD_3_CLAUSE
+_URLS = {
+    _DATASETNAME: "url or list of urls or ... ",
+}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class MozillaPontoonDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    SEACROWD_SCHEMA_NAME = "t2t"
+
+    # Config to load individual datasets per language
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{lang}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema for {lang} language",
+            schema="source",
+            subset_id=lang,
+        )
+        for lang in _LANGUAGES
+    ] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_{lang}_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema for {lang} language",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=lang,
+        )
+        for lang in _LANGUAGES
+    ]
+
+    # Config to load all datasets
+    BUILDER_CONFIGS.extend(
+        [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} source schema for all languages",
+                schema="source",
+                subset_id=_DATASETNAME,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} SEACrowd schema for all languages",
+                schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+                subset_id=_DATASETNAME,
+            )
+        ]
+    )
+
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "source_sentence": datasets.Value("string"),
+                    "target_sentence": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        # TODO: This method is tasked with downloading/extracting the data and defining the splits depending on the configuration
+
+        # If you need to access the "source" or "seacrowd" config choice, that will be in self.config.name
+
+        # LOCAL DATASETS: You do not need the dl_manager; you can ignore this argument. Make sure `gen_kwargs` in the return gets passed the right filepath
+
+        # PUBLIC DATASETS: Assign your data-dir based on the dl_manager.
+
+        # dl_manager is a datasets.download.DownloadManager that can be used to download and extract URLs; many examples use the download_and_extract method; see the DownloadManager docs here: https://huggingface.co/docs/datasets/package_reference/builder_classes.html#datasets.DownloadManager
+
+        # dl_manager can accept any type of nested list/dict and will give back the same structure with the url replaced with the path to local files.
+
+        # TODO: KEEP if your dataset is PUBLIC; remove if not
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        # TODO: KEEP if your dataset is LOCAL; remove if NOT
+        if self.config.data_dir is None:
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        else:
+            data_dir = self.config.data_dir
+
+        # Not all datasets have predefined canonical train/val/test splits.
+        # If your dataset has no predefined splits, use datasets.Split.TRAIN for all of the data.
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train.jsonl"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "test.jsonl"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "dev.jsonl"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+
+    # TODO: change the args of this function to match the keys in `gen_kwargs`. You may add any necessary kwargs.
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        for index, row in enumerate(data):
+            if self.config.schema == "source":
+                example = row
+
+            elif self.config.schema == f"seacrowd_{SEACROWD_SCHEMA_NAME}":
+                example = {
+                    "id": str(index),
+                    "text_1": row["source_sentence"],
+                    "text_2": row["target_sentence"],
+                    "text_1_name": "eng",
+                    "text_2_name": lang,
+                }
+            
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
+
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)


### PR DESCRIPTION
Closes #216.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
