### PR TITLE
Closes #112 | Implement Dataloader for Wisesight Thai Corpus

### DIFF
--- a/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
+++ b/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 
 import datasets
-import json
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME
-
+from seacrowd.utils.constants import (DEFAULT_SEACROWD_VIEW_NAME,
+                                      DEFAULT_SOURCE_VIEW_NAME, Licenses,
+                                      Tasks)
 
 _CITATION = """\
 @software{bact_2019_3457447,
@@ -41,7 +42,6 @@ _CITATION = """\
 
 
 _DATASETNAME = "wisesight_thai_sentiment"
-
 
 
 _DESCRIPTION = """\
@@ -173,9 +173,5 @@ class WisesightSentimentDataset(datasets.GeneratorBasedBuilder):
                     data = json.loads(row)
                     texts = data["texts"]
                     category = data["category"]
-                    ex = {
-                        "id": str(id_),
-                        "text": texts,
-                        "label": category
-                    }
+                    ex = {"id": str(id_), "text": texts, "label": category}
                     yield id_, ex

--- a/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
+++ b/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
-from typing import Dict, List, Tuple
 
 import datasets
 import json
@@ -87,12 +85,10 @@ _URLS = {
     _DATASETNAME: "https://github.com/PyThaiNLP/wisesight-sentiment/raw/master/huggingface/data.zip",
 }
 
-# TODO: add supported task by dataset. One dataset may support multiple tasks
+
 _SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
 
-# TODO: set this to a version that is associated with the dataset. if none exists use "1.0.0"
-#  This version doesn't have to be consistent with semantic versioning. Anything that is
-#  provided by the original dataset as a version goes.
+
 _SOURCE_VERSION = "1.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
@@ -101,7 +97,7 @@ _SEACROWD_VERSION = "1.0.0"
 class WisesightSentimentDataset(datasets.GeneratorBasedBuilder):
     """Wisesight Sentiment Corpus: Social media messages in Thai language with sentiment category (positive, neutral, negative, question)"""
 
-    _DOWNLOAD_URL = _URLS["_DATASETNAME"]
+    _DOWNLOAD_URL = _URLS[_DATASETNAME]
     _TRAIN_FILE = "train.jsonl"
     _VAL_FILE = "valid.jsonl"
     _TEST_FILE = "test.jsonl"

--- a/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
+++ b/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
@@ -77,7 +77,7 @@ _HOMEPAGE = "https://github.com/PyThaiNLP/wisesight-sentiment"
 _LANGUAGES = ["tha"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 
 
-_LICENSE = "Creative Commons Zero v1.0 Universal license"
+_LICENSE = Licenses.CC0_1_0
 
 
 _LOCAL = False
@@ -98,10 +98,10 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class WisesightSentiment(datasets.GeneratorBasedBuilder):
+class WisesightSentimentDataset(datasets.GeneratorBasedBuilder):
     """Wisesight Sentiment Corpus: Social media messages in Thai language with sentiment category (positive, neutral, negative, question)"""
 
-    _DOWNLOAD_URL = "https://github.com/PyThaiNLP/wisesight-sentiment/raw/master/huggingface/data.zip"
+    _DOWNLOAD_URL = _URLS["_DATASETNAME"]
     _TRAIN_FILE = "train.jsonl"
     _VAL_FILE = "valid.jsonl"
     _TEST_FILE = "test.jsonl"
@@ -139,7 +139,8 @@ class WisesightSentiment(datasets.GeneratorBasedBuilder):
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,
-            homepage="https://github.com/PyThaiNLP/wisesight-sentiment",
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
             citation=_CITATION,
         )
 

--- a/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
+++ b/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
@@ -1,0 +1,184 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import json
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_SEACROWD_VIEW_NAME
+
+
+_CITATION = """\
+@software{bact_2019_3457447,
+  author       = {Suriyawongkul, Arthit and
+                  Chuangsuwanich, Ekapol and
+                  Chormai, Pattarawat and
+                  Polpanumas, Charin},
+  title        = {PyThaiNLP/wisesight-sentiment: First release},
+  month        = sep,
+  year         = 2019,
+  publisher    = {Zenodo},
+  version      = {v1.0},
+  doi          = {10.5281/zenodo.3457447},
+  url          = {https://doi.org/10.5281/zenodo.3457447}
+}
+"""
+
+
+_DATASETNAME = "wisesight_thai_sentiment"
+
+
+
+_DESCRIPTION = """\
+Wisesight Sentiment Corpus: Social media messages in Thai language with sentiment category (positive, neutral, negative, question)
+* Released to public domain under Creative Commons Zero v1.0 Universal license.
+* Category (Labels): {"pos": 0, "neu": 1, "neg": 2, "q": 3}
+* Size: 26,737 messages
+* Language: Central Thai
+* Style: Informal and conversational. With some news headlines and advertisement.
+* Time period: Around 2016 to early 2019. With small amount from other period.
+* Domains: Mixed. Majority are consumer products and services (restaurants, cosmetics, drinks, car, hotels), with some current affairs.
+* Privacy:
+    * Only messages that made available to the public on the internet (websites, blogs, social network sites).
+    * For Facebook, this means the public comments (everyone can see) that made on a public page.
+    * Private/protected messages and messages in groups, chat, and inbox are not included.
+* Alternations and modifications:
+    * Keep in mind that this corpus does not statistically represent anything in the language register.
+    * Large amount of messages are not in their original form. Personal data are removed or masked.
+    * Duplicated, leading, and trailing whitespaces are removed. Other punctuations, symbols, and emojis are kept intact.
+    (Mis)spellings are kept intact.
+    * Messages longer than 2,000 characters are removed.
+    * Long non-Thai messages are removed. Duplicated message (exact match) are removed.
+* More characteristics of the data can be explore: https://github.com/PyThaiNLP/wisesight-sentiment/blob/master/exploration.ipynb
+"""
+
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
+
+_HOMEPAGE = "https://github.com/PyThaiNLP/wisesight-sentiment"
+
+_LANGUAGES = ["tha"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+
+_LICENSE = "Creative Commons Zero v1.0 Universal license"
+
+
+_LOCAL = False
+
+
+_URLS = {
+    _DATASETNAME: "https://github.com/PyThaiNLP/wisesight-sentiment/raw/master/huggingface/data.zip",
+}
+
+# TODO: add supported task by dataset. One dataset may support multiple tasks
+_SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+# TODO: set this to a version that is associated with the dataset. if none exists use "1.0.0"
+#  This version doesn't have to be consistent with semantic versioning. Anything that is
+#  provided by the original dataset as a version goes.
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class WisesightSentiment(datasets.GeneratorBasedBuilder):
+    """Wisesight Sentiment Corpus: Social media messages in Thai language with sentiment category (positive, neutral, negative, question)"""
+
+    _DOWNLOAD_URL = "https://github.com/PyThaiNLP/wisesight-sentiment/raw/master/huggingface/data.zip"
+    _TRAIN_FILE = "train.jsonl"
+    _VAL_FILE = "valid.jsonl"
+    _TEST_FILE = "test.jsonl"
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="wisesight_thai_sentiment_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description="Wisesight Sentiment Corpus Source version (positive, neutral, negative, question)",
+            schema="source",
+            subset_id="wisesight_thai_sentiment",
+        ),
+        SEACrowdConfig(
+            name="wisesight_thai_sentiment_seacrowd_text",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description="Wisesight Sentiment Corpus Seacrowd version (positive, neutral, negative, question)",
+            schema="seacrowd_text",
+            subset_id="wisesight_thai_sentiment",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "wisesight_thai_sentiment_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "texts": datasets.Value("string"),
+                    "category": datasets.features.ClassLabel(names=["pos", "neu", "neg", "q"]),
+                }
+            )
+        elif self.config.schema == "seacrowd_text":
+            features = schemas.text_features(["pos", "neu", "neg", "q"])
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage="https://github.com/PyThaiNLP/wisesight-sentiment",
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        arch_path = dl_manager.download_and_extract(self._DOWNLOAD_URL)
+        data_dir = os.path.join(arch_path, "data")
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": os.path.join(data_dir, self._TRAIN_FILE)},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": os.path.join(data_dir, self._VAL_FILE)},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": os.path.join(data_dir, self._TEST_FILE)},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """Generate WisesightSentiment examples."""
+        with open(filepath, encoding="utf-8") as f:
+            if self.config.schema == "source":
+                for id_, row in enumerate(f):
+                    data = json.loads(row)
+                    texts = data["texts"]
+                    category = data["category"]
+                    yield id_, {"texts": texts, "category": category}
+
+            elif self.config.schema == "seacrowd_text":
+                for id_, row in enumerate(f):
+                    data = json.loads(row)
+                    texts = data["texts"]
+                    category = data["category"]
+                    ex = {
+                        "id": str(id_),
+                        "text": texts,
+                        "label": category
+                    }
+                    yield id_, ex

--- a/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
+++ b/seacrowd/sea_datasets/wisesight_thai_sentiment/wisesight_thai_sentiment.py
@@ -77,7 +77,7 @@ _HOMEPAGE = "https://github.com/PyThaiNLP/wisesight-sentiment"
 _LANGUAGES = ["tha"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 
 
-_LICENSE = Licenses.CC0_1_0
+_LICENSE = Licenses.CC0_1_0.value
 
 
 _LOCAL = False


### PR DESCRIPTION
Closes #112 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [ ] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
