### PR TITLE
Add pyarrow to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ openpyxl==3.1.2
 translate-toolkit==3.7.3
 typing_extensions
 scikit-learn==1.1.2
+pyarrow


### PR DESCRIPTION
Relevant for reading parquet files.
Implicit dependency for pandas when executing pd.read_parquet(..., engine="pyarrow")

Related #242
