### PR TITLE
Closes #264 | Create dataset loader for mySentence #264

### DIFF
--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -52,7 +52,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class mysentenceDataset(datasets.GeneratorBasedBuilder):
+class MysentenceDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
     BUILDER_CONFIGS = [

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -71,7 +71,7 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 
-class mysentencesDataset(datasets.GeneratorBasedBuilder):
+class mysentenceDataset(datasets.GeneratorBasedBuilder):
     """mySentence is a corpus with a total size of around 55K for Myanmar sentence segmentation. In formal Burmese (Myanmar language), sentences are grammatically
     structured and typically end with the "။" pote-ma symbol. However, informal language, more commonly used in daily conversations due to its natural flow, does not
     always follow predefined rules for ending sentences, making it challenging for machines to identify sentence boundaries. In this corpus, each token of the sentences and paragraphs is tagged from start to finish."""
@@ -81,42 +81,51 @@ class mysentencesDataset(datasets.GeneratorBasedBuilder):
     print(schemas.seq_label)
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name="mysentences_source",
+            name="sentences_source",
             version=SOURCE_VERSION,
             description="sentences source schema",
             schema="source",
-            subset_id="mysentences",
+            subset_id="sentences",
         ),
         SEACrowdConfig(
-            name="mysentences_seacrowd_seq_label",
+            name="sentences_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentences SEACrowd schema",
             schema="seacrowd_seacrowd_seq_label",
-            subset_id="mysentences",
+            subset_id="sentences",
         ),
         SEACrowdConfig(
-            name="mysentences_para_source",
+            name="sentences+paragraphs_source",
             version=SOURCE_VERSION,
             description="sentences para source schema",
             schema="source",
-            subset_id="mysentences_para",
+            subset_id="sentences+paragraphs",
         ),
         SEACrowdConfig(
-            name="mysentences_para_seacrowd_seq_label",
+            name="sentences+paragraphs_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentence para SEACrowd schema",
             schema="seacrowd_seacrowd_seq_label",
-            subset_id="mysentences_para",
+            subset_id="sentences+paragraphs",
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = "mysentences_source"
+    DEFAULT_CONFIG_NAME = "sentences_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "tokens": datasets.Sequence(datasets.Value("string")),
+                    "labels": datasets.Sequence(datasets.Value("string")),
+                }
+            )
+        else:
+            features = schemas.seq_label_features(["B", "O", "N", "E"])
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
-            features=schemas.seq_label_features(["B", "O", "N", "E"]),  # B (Begin), O (Other), N (Next), and E (End)
+            features=features,  # B (Begin), O (Other), N (Next), and E (End)
             homepage=_HOMEPAGE,
             license=_LICENSE,
             citation=_CITATION,
@@ -124,9 +133,9 @@ class mysentencesDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        if self.config.subset_id == "mysentences":
+        if self.config.subset_id == "sentences":
             DATA_URL_ = _URLS["sent"]
-        elif self.config.subset_id == "mysentences_para":
+        elif self.config.subset_id == "sentences+paragraphs":
             DATA_URL_ = _URLS["sent+para"]
         else:
             raise ValueError(f"No related dataset id for {self.config.subset_id}")

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -1,0 +1,165 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{Aung_Kyaw Thu_Hlaing_2023, place={Nonthaburi, Thailand}, title={mySentence: Sentence Segmentation for Myanmar Language
+using Neural Machine Translation Approach}, volume={9}, url={https://ph05.tci-thaijo.org/index.php/JIIST/article/view/87}, abstractNote=
+{&amp;lt;p&amp;gt;&amp;amp;nbsp;A sentence is an independent unit which is a string of complete words containing valuable information of the text.
+In informal Myanmar Language, for which most of NLP applications like Automatic Speech Recognition (ASR) are used, there is no predefined rule to
+mark the end of sentence. In this paper, we contributed the first corpus for Myanmar Sentence Segmentation and proposed the first systematic study
+with Machine Learning based Sequence Tagging as baseline and Neural Machine Translation approach. Before conducting the experiments, we prepared two
+types of data - one containing only sentences and the other containing both sentences and paragraphs. We trained each model on both types of data and
+evaluated the results on both types of test data. The accuracies were measured in terms of Bilingual Evaluation Understudy (BLEU) and character n-gram
+F-score (CHRF ++) scores. Word Error Rate (WER) was also used for the detailed study of error analysis. The experimental results show that Sequence-to-Sequence
+architecture based Neural Machine Translation approach with the best BLEU score (99.78), which is trained on both sentence-level and paragraph-level data, achieved better CHRF
+++ scores (+18.4) and (+16.7) than best results of such machine learning models on both test data.&amp;lt;/p&amp;gt;}, number={October}, journal={Journal of Intelligent Informatics
+and Smart Technology}, author={Aung, Thura and Kyaw Thu , Ye and Hlaing , Zar Zar}, year={2023}, month={Nov.}, pages={e001} }
+"""
+
+_DATASETNAME = "mysentence"
+_DESCRIPTION = """\
+mySentence is a corpus with a total size of around 55K for Myanmar sentence segmentation. In formal Burmese (Myanmar language), sentences are grammatically structured
+and typically end with the "။" pote-ma symbol. However, informal language, more commonly used in daily conversations due to its natural flow, does not always follow predefined
+rules for ending sentences, making it challenging for machines to identify sentence boundaries. In this corpus, each token of the sentences and paragraphs is tagged from start to finish.
+"""
+
+_HOMEPAGE = "https://github.com/ye-kyaw-thu/mySentence"
+
+_LANGUAGES = ["mya"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value  # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_URLS = {
+    "sent": {
+        "train": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent/sent_tagged/train.tagged",
+        "valid": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent/sent_tagged/valid.tagged",
+        "test": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent/sent_tagged/test.tagged",
+    },
+    "sent+para": {
+        "train": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent+para/sent+para_tagged/train.tagged",
+        "valid": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent+para/sent+para_tagged/valid.tagged",
+        "test": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent+para/sent+para_tagged/test.tagged",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.POS_TAGGING]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class mysentencesDataset(datasets.GeneratorBasedBuilder):
+    """mySentence is a corpus with a total size of around 55K for Myanmar sentence segmentation. In formal Burmese (Myanmar language), sentences are grammatically
+    structured and typically end with the "။" pote-ma symbol. However, informal language, more commonly used in daily conversations due to its natural flow, does not
+    always follow predefined rules for ending sentences, making it challenging for machines to identify sentence boundaries. In this corpus, each token of the sentences and paragraphs is tagged from start to finish."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    print(schemas.seq_label)
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name="mysentences_source",
+            version=SOURCE_VERSION,
+            description="sentences source schema",
+            schema="source",
+            subset_id="mysentences",
+        ),
+        SEACrowdConfig(
+            name="mysentences_seacrowd_seq_label",
+            version=SEACROWD_VERSION,
+            description="sentences SEACrowd schema",
+            schema="seacrowd_seacrowd_seq_label",
+            subset_id="mysentences",
+        ),
+        SEACrowdConfig(
+            name="mysentences_para_source",
+            version=SOURCE_VERSION,
+            description="sentences para source schema",
+            schema="source",
+            subset_id="mysentences_para",
+        ),
+        SEACrowdConfig(
+            name="mysentences_para_seacrowd_seq_label",
+            version=SEACROWD_VERSION,
+            description="sentence para SEACrowd schema",
+            schema="seacrowd_seacrowd_seq_label",
+            subset_id="mysentences_para",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mysentences_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=schemas.seq_label_features(["B", "O", "N", "E"]),  # B (Begin), O (Other), N (Next), and E (End)
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.subset_id == "mysentences":
+            DATA_URL_ = _URLS["sent"]
+        elif self.config.subset_id == "mysentences_para":
+            DATA_URL_ = _URLS["sent+para"]
+        else:
+            raise ValueError(f"No related dataset id for {self.config.subset_id}")
+
+        data_dir = dl_manager.download_and_extract(DATA_URL_)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": data_dir["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_dir["test"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir["valid"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+
+        with open(filepath, "r") as filein:
+            examples = [line.strip("\n").split(" ") for line in filein.readlines()]
+            for eid, exam in enumerate(examples):
+                tokens = []
+                pos = []
+                for tok_chunk in exam:
+                    tok_ = tok_chunk.split("/")
+                    tokens.append(tok_[0])
+                    pos.append(tok_[1])
+                yield eid, {"id": str(eid), "tokens": tokens, "labels": pos}

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -71,18 +71,18 @@ class MysentenceDataset(datasets.GeneratorBasedBuilder):
             subset_id=f"{_DATASETNAME}",
         ),
         SEACrowdConfig(
-            name=f"{_DATASETNAME}+paragraphs_source",
+            name=f"{_DATASETNAME}_and_paragraphs_source",
             version=SOURCE_VERSION,
             description="sentences para source schema",
             schema="source",
-            subset_id=f"{_DATASETNAME}+paragraphs",
+            subset_id=f"{_DATASETNAME}_and_paragraphs",
         ),
         SEACrowdConfig(
-            name=f"{_DATASETNAME}+paragraphs_seacrowd_seq_label",
+            name=f"{_DATASETNAME}_and_paragraphs_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentence para SEACrowd schema",
             schema="seacrowd_seq_label",
-            subset_id=f"{_DATASETNAME}+paragraphs",
+            subset_id=f"{_DATASETNAME}_and_paragraphs",
         ),
     ]
 

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -1,18 +1,4 @@
 # coding=utf-8
-# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -22,7 +8,6 @@ from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import Licenses, Tasks
 
-# TODO: Add BibTeX citation
 _CITATION = """\
 @article{Aung_Kyaw Thu_Hlaing_2023, place={Nonthaburi, Thailand}, title={mySentence: Sentence Segmentation for Myanmar Language
 using Neural Machine Translation Approach}, volume={9}, url={https://ph05.tci-thaijo.org/index.php/JIIST/article/view/87}, abstractNote=
@@ -46,13 +31,9 @@ rules for ending sentences, making it challenging for machines to identify sente
 """
 
 _HOMEPAGE = "https://github.com/ye-kyaw-thu/mySentence"
-
-_LANGUAGES = ["mya"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
-
-_LICENSE = Licenses.CC_BY_NC_SA_4_0.value  # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
-
+_LANGUAGES = ["mya"]
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value
 _LOCAL = False
-
 _URLS = {
     "sent": {
         "train": "https://raw.githubusercontent.com/ye-kyaw-thu/mySentence/main/ver1.0/data/data-sent/sent_tagged/train.tagged",
@@ -72,45 +53,41 @@ _SEACROWD_VERSION = "1.0.0"
 
 
 class mysentenceDataset(datasets.GeneratorBasedBuilder):
-    """mySentence is a corpus with a total size of around 55K for Myanmar sentence segmentation. In formal Burmese (Myanmar language), sentences are grammatically
-    structured and typically end with the "။" pote-ma symbol. However, informal language, more commonly used in daily conversations due to its natural flow, does not
-    always follow predefined rules for ending sentences, making it challenging for machines to identify sentence boundaries. In this corpus, each token of the sentences and paragraphs is tagged from start to finish."""
-
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
     # print(schemas.seq_label)
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name="mysentence_source",
+            name=f"{_DATASETNAME}_source",
             version=SOURCE_VERSION,
-            description="sentences source schema",
+            description=_DESCRIPTION,
             schema="source",
-            subset_id="mysentence",
+            subset_id=f"{_DATASETNAME}",
         ),
         SEACrowdConfig(
-            name="mysentence_seacrowd_seq_label",
+            name=f"{_DATASETNAME}_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentences SEACrowd schema",
             schema="seacrowd_seq_label",
-            subset_id="mysentence",
+            subset_id=f"{_DATASETNAME}",
         ),
         SEACrowdConfig(
-            name="mysentence+paragraphs_source",
+            name=f"{_DATASETNAME}+paragraphs_source",
             version=SOURCE_VERSION,
             description="sentences para source schema",
             schema="source",
-            subset_id="mysentence+paragraphs",
+            subset_id=f"{_DATASETNAME}+paragraphs",
         ),
         SEACrowdConfig(
-            name="mysentence+paragraphs_seacrowd_seq_label",
+            name=f"{_DATASETNAME}+paragraphs_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentence para SEACrowd schema",
             schema="seacrowd_seq_label",
-            subset_id="mysentence+paragraphs",
+            subset_id=f"{_DATASETNAME}+paragraphs",
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = "mysentence_source"
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -133,9 +110,9 @@ class mysentenceDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        if self.config.subset_id == "mysentence":
+        if self.config.subset_id == f"{_DATASETNAME}":
             DATA_URL_ = _URLS["sent"]
-        elif self.config.subset_id == "mysentence+paragraphs":
+        elif self.config.subset_id == f"{_DATASETNAME}+paragraphs":
             DATA_URL_ = _URLS["sent+para"]
         else:
             raise ValueError(f"No related dataset id for {self.config.subset_id}")

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -78,39 +78,39 @@ class mysentenceDataset(datasets.GeneratorBasedBuilder):
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
-    print(schemas.seq_label)
+    # print(schemas.seq_label)
     BUILDER_CONFIGS = [
         SEACrowdConfig(
-            name="sentences_source",
+            name="mysentence_source",
             version=SOURCE_VERSION,
             description="sentences source schema",
             schema="source",
-            subset_id="sentences",
+            subset_id="mysentence",
         ),
         SEACrowdConfig(
-            name="sentences_seacrowd_seq_label",
+            name="mysentence_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentences SEACrowd schema",
-            schema="seacrowd_seacrowd_seq_label",
-            subset_id="sentences",
+            schema="seacrowd_seq_label",
+            subset_id="mysentence",
         ),
         SEACrowdConfig(
-            name="sentences+paragraphs_source",
+            name="mysentence+paragraphs_source",
             version=SOURCE_VERSION,
             description="sentences para source schema",
             schema="source",
-            subset_id="sentences+paragraphs",
+            subset_id="mysentence+paragraphs",
         ),
         SEACrowdConfig(
-            name="sentences+paragraphs_seacrowd_seq_label",
+            name="mysentence+paragraphs_seacrowd_seq_label",
             version=SEACROWD_VERSION,
             description="sentence para SEACrowd schema",
-            schema="seacrowd_seacrowd_seq_label",
-            subset_id="sentences+paragraphs",
+            schema="seacrowd_seq_label",
+            subset_id="mysentence+paragraphs",
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = "sentences_source"
+    DEFAULT_CONFIG_NAME = "mysentence_source"
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -133,9 +133,9 @@ class mysentenceDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        if self.config.subset_id == "sentences":
+        if self.config.subset_id == "mysentence":
             DATA_URL_ = _URLS["sent"]
-        elif self.config.subset_id == "sentences+paragraphs":
+        elif self.config.subset_id == "mysentence+paragraphs":
             DATA_URL_ = _URLS["sent+para"]
         else:
             raise ValueError(f"No related dataset id for {self.config.subset_id}")

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -55,7 +55,6 @@ _SEACROWD_VERSION = "1.0.0"
 class mysentenceDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
-    # print(schemas.seq_label)
     BUILDER_CONFIGS = [
         SEACrowdConfig(
             name=f"{_DATASETNAME}_source",
@@ -122,7 +121,6 @@ class mysentenceDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                # Whatever you put in gen_kwargs will be passed to _generate_examples
                 gen_kwargs={"filepath": data_dir["train"]},
             ),
             datasets.SplitGenerator(

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -10,17 +10,38 @@ from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @article{Aung_Kyaw Thu_Hlaing_2023, place={Nonthaburi, Thailand}, title={mySentence: Sentence Segmentation for Myanmar Language
-using Neural Machine Translation Approach}, volume={9}, url={https://ph05.tci-thaijo.org/index.php/JIIST/article/view/87}, abstractNote=
-{&amp;lt;p&amp;gt;&amp;amp;nbsp;A sentence is an independent unit which is a string of complete words containing valuable information of the text.
-In informal Myanmar Language, for which most of NLP applications like Automatic Speech Recognition (ASR) are used, there is no predefined rule to
-mark the end of sentence. In this paper, we contributed the first corpus for Myanmar Sentence Segmentation and proposed the first systematic study
-with Machine Learning based Sequence Tagging as baseline and Neural Machine Translation approach. Before conducting the experiments, we prepared two
-types of data - one containing only sentences and the other containing both sentences and paragraphs. We trained each model on both types of data and
-evaluated the results on both types of test data. The accuracies were measured in terms of Bilingual Evaluation Understudy (BLEU) and character n-gram
-F-score (CHRF ++) scores. Word Error Rate (WER) was also used for the detailed study of error analysis. The experimental results show that Sequence-to-Sequence
-architecture based Neural Machine Translation approach with the best BLEU score (99.78), which is trained on both sentence-level and paragraph-level data, achieved better CHRF
-++ scores (+18.4) and (+16.7) than best results of such machine learning models on both test data.&amp;lt;/p&amp;gt;}, number={October}, journal={Journal of Intelligent Informatics
-and Smart Technology}, author={Aung, Thura and Kyaw Thu , Ye and Hlaing , Zar Zar}, year={2023}, month={Nov.}, pages={e001} }
+using Neural Machine Translation Approach}, volume={9}, url={https://ph05.tci-thaijo.org/index.php/JIIST/article/view/87},
+number={October}, 
+abstract="In the informal Myanmar language, for which most NLP applications are used, there is no predefined rule to mark the end of the sentence.
+Therefore, in this paper, we contributed the first Myanmar sentence segmentation corpus and systemat
+ically experimented with twelve neural sequence
+labeling architectures trained and tested on both sentence and sentence+paragraph data. The word LSTM + Softmax achieved the highest accuracy of 99.95{\%}
+while trained and tested on sentence-only data and 97.40{\%} while trained and tested on sentence + paragraph data.",
+journal={Journal of Intelligent Informatics
+and Smart Technology}, author={Aung, Thura and Kyaw Thu , Ye and Hlaing , Zar Zar}, year={2023}, month={Nov.}, pages={e001} };
+
+@InProceedings{10.1007/978-3-031-36886-8_24,
+author="Thu, Ye Kyaw
+and Aung, Thura
+and Supnithi, Thepchai",
+editor="Nguyen, Ngoc Thanh
+and Le-Minh, Hoa
+and Huynh, Cong-Phap
+and Nguyen, Quang-Vu",
+title="Neural Sequence Labeling Based Sentence Segmentation for Myanmar Language",
+booktitle="The 12th Conference on Information Technology and Its Applications",
+year="2023",
+publisher="Springer Nature Switzerland",
+address="Cham",
+pages="285--296",
+abstract="In the informal Myanmar language, for which most NLP applications are used, there is no predefined rule to mark the end of the sentence.
+Therefore, in this paper, we contributed the first Myanmar sentence segmentation corpus and systemat
+ically experimented with twelve neural sequence
+labeling architectures trained and tested on both sentence and sentence+paragraph data. The word LSTM + Softmax achieved the highest accuracy of 99.95{\%}
+while trained and tested on sentence-only data and 97.40{\%} while trained and tested on sentence + paragraph data.",
+isbn="978-3-031-36886-8"
+}
+
 """
 
 _DATASETNAME = "mysentence"

--- a/seacrowd/sea_datasets/mysentence/mysentence.py
+++ b/seacrowd/sea_datasets/mysentence/mysentence.py
@@ -132,7 +132,7 @@ class MysentenceDataset(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         if self.config.subset_id == f"{_DATASETNAME}":
             DATA_URL_ = _URLS["sent"]
-        elif self.config.subset_id == f"{_DATASETNAME}+paragraphs":
+        elif self.config.subset_id == f"{_DATASETNAME}_and_paragraphs":
             DATA_URL_ = _URLS["sent+para"]
         else:
             raise ValueError(f"No related dataset id for {self.config.subset_id}")


### PR DESCRIPTION
Closes #264 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
