### PR TITLE
Closes #157 | Create dataset loader for M3Exam

### DIFF
--- a/seacrowd/sea_datasets/m3exam/m3exam.py
+++ b/seacrowd/sea_datasets/m3exam/m3exam.py
@@ -1,0 +1,178 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+import json
+import datasets
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+import zipfile
+
+_CITATION = """\
+@article{zhang2023m3exam,
+      title={M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models},
+      author={Wenxuan Zhang and Sharifah Mahani Aljunied and Chang Gao and Yew Ken Chia and Lidong Bing},
+      year={2023},
+      eprint={2306.05179},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
+
+_DATASETNAME = "m3exam"
+
+_DESCRIPTION = """\
+M3Exam is a novel benchmark sourced from real and official human exam questions for evaluating LLMs\
+in a multilingual, multimodal, and multilevel context. In total, M3Exam contains 12,317 questions in 9\
+diverse languages with three educational levels, where about 23% of the questions require processing images\
+for successful solving. M3Exam dataset covers 3 languages spoken in Southeast Asia.
+"""
+
+_HOMEPAGE = "https://github.com/DAMO-NLP-SG/M3Exam"
+
+_LANGUAGES = ["jav", "tha", "vie"]
+_LANG_MAPPER = {"jav": "javanese", "tha": "thai", "vie": "vietnamese"}
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value
+
+_LOCAL = False
+_PASSWORD = "12317".encode("utf-8")  # password to unzip dataset after downloading
+_URLS = {
+    _DATASETNAME: "https://drive.google.com/uc?id=1eREETRklmXJLXrNPTyHxQ3RFdPhq_Nes",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class M3Exam(datasets.GeneratorBasedBuilder):
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{lang}_source", version=datasets.Version(_SOURCE_VERSION), description=f"{_DATASETNAME} source schema", schema="source", subset_id=f"{_DATASETNAME}") for lang in _LANGUAGES] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{lang}_seacrowd_qa",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema="seacrowd_qa",
+            subset_id=f"{_DATASETNAME}",
+        )
+        for lang in _LANGUAGES
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "question_text": datasets.Value("string"),
+                    "background_description": datasets.Sequence(datasets.Value("string")),
+                    "answer_text": datasets.Value("string"),
+                    "options": datasets.Sequence(datasets.Value("string")),
+                    "language": datasets.Value("string"),
+                    "level": datasets.Value("string"),
+                    "subject": datasets.Value("string"),
+                    "subject_category": datasets.Value("string"),
+                    "year": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "seacrowd_qa":
+            features = schemas.qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        lang = self.config.name.split("_")[1]
+
+        dl_manager._download_config = {"pwd": _PASSWORD}
+        data_dir = dl_manager.download(urls)
+
+        if not os.path.exists(data_dir + ".zip"):
+            os.rename(data_dir, data_dir + ".zip")
+
+        with zipfile.ZipFile(data_dir + ".zip", "r") as zip_ref:
+            zip_ref.extractall(data_dir, pwd=_PASSWORD)  # unzipping with password
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, f"data/text-question/{_LANG_MAPPER[lang]}-questions-test.json"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, f"data/text-question/{_LANG_MAPPER[lang]}-questions-dev.json"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(filepath, "r") as file:
+            data = json.load(file)
+
+        if self.config.schema == "source":
+            idx = 0
+            for json_obj in data:
+                example = {
+                    "question_text": json_obj["question_text"],
+                    "background_description": json_obj["background_description"] if "background_description" in json_obj.keys() else None,
+                    "answer_text": json_obj["answer_text"],
+                    "options": json_obj["options"],
+                    "language": json_obj["language"] if "language" in json_obj.keys() else None,
+                    "level": json_obj["level"] if "level" in json_obj.keys() else None,
+                    "subject": json_obj["subject"] if "subject" in json_obj.keys() else None,
+                    "subject_category": json_obj["subject_category"] if "subject_category" in json_obj.keys() else None,
+                    "year": json_obj["year"] if "year" in json_obj.keys() else None,
+                }
+                yield idx, example
+                idx += 1
+
+        elif self.config.schema == "seacrowd_qa":
+            idx = 0
+            for json_obj in data:
+                example = {
+                    "id": idx,
+                    "question_id": idx,
+                    "document_id": idx,
+                    "question": json_obj["question_text"],
+                    "type": "multiple_choice",
+                    "choices": json_obj["options"],
+                    "context": "",
+                    "answer": [answer for answer in json_obj["options"] if json_obj["answer_text"] == answer[0]],
+                    "meta": {},
+                }
+                yield idx, example
+                idx += 1

--- a/seacrowd/sea_datasets/m3exam/m3exam.py
+++ b/seacrowd/sea_datasets/m3exam/m3exam.py
@@ -112,7 +112,6 @@ class M3Exam(datasets.GeneratorBasedBuilder):
         urls = _URLS[_DATASETNAME]
         lang = self.config.name.split("_")[1]
 
-        dl_manager._download_config = {"pwd": _PASSWORD}
         data_dir = dl_manager.download(urls)
 
         if not os.path.exists(data_dir + ".zip"):


### PR DESCRIPTION
Closes #157 

Note: zipfile library is used to unzip data, because password is needed. Could not find how pass password using dl_manager.download_and_extract() function.

Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
