### PR TITLE
ishan/utf-shared-alone Update common_parser.py

### DIFF
--- a/seacrowd/utils/common_parser.py
+++ b/seacrowd/utils/common_parser.py
@@ -6,7 +6,7 @@ from conllu import parse
 
 def load_conll_data(file_path):
     # Read file
-    data = open(file_path, "r").readlines()
+    data = open(file_path, "r", encoding="utf8").readlines()
 
     # Prepare buffer
     dataset = []


### PR DESCRIPTION
This PR relates to https://github.com/SEACrowd/seacrowd-datahub/pull/247#discussion_r1440043322
 and is linked to #247


As discussed in https://github.com/SEACrowd/seacrowd-datahub/pull/328, separating loader efforts from common utility efforts.

Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [ ] Confirm that this PR is linked to the dataset issue.
- [ ] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [ ] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [ ] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [ ] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [ ] Confirm dataloader script works with `datasets.load_dataset` function.
- [ ] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
