### PR TITLE
Update template.py instruction for dataloader class name

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -66,7 +66,7 @@ The objective of datasheet review is to ensure that all dataloaders in SEACrowd 
  b. Execute `datasets.load_dataset` check based on config list (a)
  c. Check on the dataset schema & few first examples for plausibility.
 5. Follows some general rules/conventions:
-    1. Use `PascalCase` for the dataloader class name (optional: “Dataset” can be appended to the Dataloader class name, see templates/templates.py for example).
+    1. Use `PascalCase` for the dataloader class name (optional: “Dataset” can be appended to the Dataloader class name, see `templates/template.py` for example).
     2. Use lowercase word characters (regex identifier: `\w`) for schema column names, including the `source` schema if the original dataset doesn’t follow it.
 6. The code aligns with the `black` formatter:
 use this `make check_file=seacrowd/sea_datasets/{dataloader}/{dataloader}.py`

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -66,8 +66,8 @@ The objective of datasheet review is to ensure that all dataloaders in SEACrowd 
  b. Execute `datasets.load_dataset` check based on config list (a)
  c. Check on the dataset schema & few first examples for plausibility.
 5. Follows some general rules/conventions:
-    1. `PascalCase` for dataloader class name (and “Dataset” is contained in the suffix of the class name).
-    2. Lowercase word characters (regex identifier: `\w`) for schema column names, including the `source` schema if the original dataset doesn’t follow it.
+    1. Use `PascalCase` for the dataloader class name (optional: “Dataset” can be appended to the Dataloader class name, see templates/templates.py for example).
+    2. Use lowercase word characters (regex identifier: `\w`) for schema column names, including the `source` schema if the original dataset doesn’t follow it.
 6. The code aligns with the `black` formatter:
 use this `make check_file=seacrowd/sea_datasets/{dataloader}/{dataloader}.py`
 7. Follows Dataloader Config Rule

--- a/templates/template.py
+++ b/templates/template.py
@@ -101,8 +101,8 @@ _SOURCE_VERSION = ""
 _SEACROWD_VERSION = "1.0.0"
 
 
-# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case. 
-# Suffix should contain "Dataset" (e.g. OSCAR 2201 --> Oscar2201Dataset)
+# TODO: Name the dataset class to match the script name using PascalCase instead of snake_case. 
+# optional: class name can append "Dataset" as suffix to provide better clarity (e.g. OSCAR 2201 --> Oscar2201Dataset/Oscar2201)
 class NewDataset(datasets.GeneratorBasedBuilder):
     """TODO: Short description of my dataset."""
 

--- a/templates/template.py
+++ b/templates/template.py
@@ -101,7 +101,8 @@ _SOURCE_VERSION = ""
 _SEACROWD_VERSION = "1.0.0"
 
 
-# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
+# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case. 
+# Suffix should contain "Dataset" (e.g. OSCAR 2201 --> Oscar2201Dataset)
 class NewDataset(datasets.GeneratorBasedBuilder):
     """TODO: Short description of my dataset."""
 


### PR DESCRIPTION
Issue: Reviewer Dataloader SOP instructions and template.py instructions are inconsistent regarding the dataloader class name convention.

With the current instruction at `template.py` it's not clear whether to put "Dataset" as suffix or not while the Dataloader SOP instructions makes it clear that the dataloader class name should include "Dataset" as suffix.

To minimize confusion for both reviewers and dataloader creators, we can do either:
- (a) Update the instruction at [template.py](https://github.com/SEACrowd/seacrowd-datahub/blob/master/templates/template.py)
- (b) Update the instruction at [Dataloader Review SOP](https://github.com/SEACrowd/seacrowd-datahub/blob/master/REVIEWING.md#dataloader-reviewer-sop), item 5.i

This PR implements solution (a). If solution (b) is preferred, please open a new PR and close this PR.

