### PR TITLE
Closes #338 | Created DataLoader for IndonesianNMT

### DIFF
--- a/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
+++ b/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 
 """
-The dataset is split into two: 
+The dataset is split into two:
 1. Monolingual (ends with .txt) [Indonesian, Javanese]
 2. Bilingual (ends with .tsv) [Indonesian-Javanese, Indonesian-Balinese, Indonesian-Minangkabau, Indonesian-Sundanese]
 """
-import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -26,11 +25,11 @@ import datasets
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @misc{susanto2023replicable,
-      title={Replicable Benchmarking of Neural Machine Translation (NMT) on Low-Resource Local Languages in Indonesia}, 
+      title={Replicable Benchmarking of Neural Machine Translation (NMT) on Low-Resource Local Languages in Indonesia},
       author={Lucky Susanto and Ryandito Diandaru and Adila Krisnadhi and Ayu Purwarianti and Derry Wijaya},
       year={2023},
       eprint={2311.00998},
@@ -49,9 +48,9 @@ Only the Bilingual dataset is available for this dataloader
 
 _HOMEPAGE = "https://huggingface.co/datasets/Exqrch/IndonesianNMT"
 
-_LANGUAGES = ['ind', 'jav', 'ban', 'min', 'sun']  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_LANGUAGES = ["ind", "jav", "ban", "min", "sun"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 
-_LICENSE = Licenses.CC_BY_NC_SA_4_0.value 
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value
 
 _LOCAL = False
 
@@ -62,45 +61,47 @@ _URLS = {
     "ind_min": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/id-min.tsv?download=true",
     "ind": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/bt-id-jv.id.txt?download=true",
     "jav": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/bt-id-jv.jv.txt?download=true",
-
 }
 
-_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION, Tasks.SELF_SUPERVISED_PRETRAINING]  
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION, Tasks.SELF_SUPERVISED_PRETRAINING]
 
 _SOURCE_VERSION = "1.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
 
+
 def seacrowd_config_constructor(modifier, schema, version):
     return SEACrowdConfig(
-            name=f"indonesiannmt_{modifier}_{schema}",
-            version=version,
-            description=f"indonesiannmt_{modifier} {schema} schema",
-            schema=f"{schema}",
-            subset_id="indonesiannmt",
-        )
+        name=f"indonesiannmt_{modifier}_{schema}",
+        version=version,
+        description=f"indonesiannmt_{modifier} {schema} schema",
+        schema=f"{schema}",
+        subset_id="indonesiannmt",
+    )
+
 
 class IndonesianNMT(datasets.GeneratorBasedBuilder):
-    """IndonesianNMT consists of 4 parallel datasets and 2 monolingual datasets, 
+    """IndonesianNMT consists of 4 parallel datasets and 2 monolingual datasets,
     all obtained synthetically from either gpt-3.5-turbo or text-davinci-003"""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
     BUILDER_CONFIGS = (
-        [seacrowd_config_constructor(x, 'source', _SOURCE_VERSION) for x in ['ind', 'jav']]
-        + [seacrowd_config_constructor(x, 'seacrowd_ssp', _SOURCE_VERSION) for x in ['ind', 'jav']]
-        + [seacrowd_config_constructor(x, 'source', _SOURCE_VERSION) for x in ['ind_jav', 'ind_min', 'ind_sun', 'ind_ban']]
-        + [seacrowd_config_constructor(x, 'seacrowd_t2t', _SEACROWD_VERSION) for x in ['ind_jav', 'ind_min', 'ind_sun', 'ind_ban']])
+        [seacrowd_config_constructor(x, "source", _SOURCE_VERSION) for x in ["ind", "jav"]]
+        + [seacrowd_config_constructor(x, "seacrowd_ssp", _SOURCE_VERSION) for x in ["ind", "jav"]]
+        + [seacrowd_config_constructor(x, "source", _SOURCE_VERSION) for x in ["ind_jav", "ind_min", "ind_sun", "ind_ban"]]
+        + [seacrowd_config_constructor(x, "seacrowd_t2t", _SEACROWD_VERSION) for x in ["ind_jav", "ind_min", "ind_sun", "ind_ban"]]
+    )
 
     DEFAULT_CONFIG_NAME = "indonesiannmt_ind_source"
 
     def is_mono(self):
         if self.config.schema == "seacrowd_ssp":
-            return True 
-        if 'source' in self.config.schema:
-            if len(self.config.name.split('_')) == 3:
-                return True 
+            return True
+        if "source" in self.config.schema:
+            if len(self.config.name.split("_")) == 3:
+                return True
         return False
 
     def _info(self) -> datasets.DatasetInfo:
@@ -142,11 +143,11 @@ class IndonesianNMT(datasets.GeneratorBasedBuilder):
         # ex mono: indonesiannmt_ind_source OR indonesiannmt_ind_seacrowd_ssp
         # ex para: indonesiannmt_ind_jav_source OR indonesiannmt_ind_jav_seacrowd_t2t
         is_mono = self.is_mono()
-        if 'seacrowd_ssp' in self.config.schema or is_mono:
-            lang = self.config.name.split('_')[1]
+        if "seacrowd_ssp" in self.config.schema or is_mono:
+            lang = self.config.name.split("_")[1]
             path = dl_manager.download_and_extract(_URLS[lang])
-        else:         
-            target = '_'.join(self.config.name.split('_')[1:3])
+        else:
+            target = "_".join(self.config.name.split("_")[1:3])
             url = _URLS[target]
             path = dl_manager.download_and_extract(url)
 
@@ -163,57 +164,53 @@ class IndonesianNMT(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         is_mono = self.is_mono()
-        STR_TO_ISO = {
-            'Indonesian': 'ind',
-            'Javanese': 'jav',
-            'Minangkabau': 'min',
-            'Sundanese': 'sun',
-            'Balinese': 'ban'
-        }
+        STR_TO_ISO = {"Indonesian": "ind", "Javanese": "jav", "Minangkabau": "min", "Sundanese": "sun", "Balinese": "ban"}
 
         with open(filepath, encoding="utf-8") as f:
-            flag = True  
-            if 'seacrowd_ssp' in self.config.schema or is_mono:
+            flag = True
+            if "seacrowd_ssp" in self.config.schema or is_mono:
                 for counter, row in enumerate(f):
-                    if row.strip != '':
-                        yield(counter, {
+                    if row.strip != "":
+                        yield (
+                            counter,
+                            {
                                 "id": str(counter),
                                 "text": row.strip(),
-                            }
+                            },
                         )
             elif self.config.schema == "source":
                 for counter, row in enumerate(f):
                     if flag:
-                        src, tgt = row.split('\t')
+                        src, tgt = row.split("\t")
                         tgt = tgt.strip()
                         flag = False
                     else:
                         if row.strip() != "":
-                            yield(
+                            yield (
                                 counter,
                                 {
                                     "id": str(counter),
-                                    "text_1": row.split('\t')[0].strip(),
-                                    "text_2": row.split('\t')[1].strip(),
+                                    "text_1": row.split("\t")[0].strip(),
+                                    "text_2": row.split("\t")[1].strip(),
                                     "lang_1": STR_TO_ISO[src],
                                     "lang_2": STR_TO_ISO[tgt],
-                                }
+                                },
                             )
             elif self.config.schema == "seacrowd_t2t":
                 for counter, row in enumerate(f):
                     if flag:
-                        src, tgt = row.split('\t')
+                        src, tgt = row.split("\t")
                         tgt = tgt.strip()
                         flag = False
                     else:
                         if row.strip() != "":
-                            yield(
+                            yield (
                                 counter,
                                 {
                                     "id": str(counter),
-                                    "text_1": row.split('\t')[0].strip(),
-                                    "text_2": row.split('\t')[1].strip(),
+                                    "text_1": row.split("\t")[0].strip(),
+                                    "text_2": row.split("\t")[1].strip(),
                                     "text_1_name": STR_TO_ISO[src],
                                     "text_2_name": STR_TO_ISO[tgt],
-                                }
+                                },
                             )

--- a/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
+++ b/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
@@ -221,8 +221,3 @@ class IndonesianNMT(datasets.GeneratorBasedBuilder):
                                         "text_2_name": tgt,
                                     }
                                 )
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
+++ b/seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py
@@ -1,0 +1,228 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The dataset is split into two: 
+1. Monolingual (ends with .txt) [Indonesian, Javanese]
+2. Bilingual (ends with .tsv) [Indonesian-Javanese, Indonesian-Balinese, Indonesian-Minangkabau, Indonesian-Sundanese]
+"""
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@misc{susanto2023replicable,
+      title={Replicable Benchmarking of Neural Machine Translation (NMT) on Low-Resource Local Languages in Indonesia}, 
+      author={Lucky Susanto and Ryandito Diandaru and Adila Krisnadhi and Ayu Purwarianti and Derry Wijaya},
+      year={2023},
+      eprint={2311.00998},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
+_DATASETNAME = "indonesiannmt"
+
+_DESCRIPTION = """\
+This dataset is used on the paper "Replicable Benchmarking of Neural Machine Translation (NMT) on Low-Resource Local Languages in Indonesia". This repository contains two types of data:
+1. Monolingual (*.txt) [Indonesian, Javanese]
+2. Bilingual (*.tsv) [Indonesian-Javanese, Indonesian-Balinese, Indonesian-Minangkabau, Indonesian-Sundanese]
+
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/Exqrch/IndonesianNMT"
+
+_LANGUAGES = ['ind', 'jav', 'ban', 'min', 'sun']  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value 
+
+_LOCAL = False
+
+_URLS = {
+    "parallel_ind_jav": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/id-jv.tsv?download=true",
+    "parallel_ind_sun": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/id-su.tsv?download=true",
+    "parallel_ind_ban": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/id-ban.tsv?download=true",
+    "parallel_ind_min": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/id-min.tsv?download=true",
+    "mono_ind": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/bt-id-jv.id.txt?download=true",
+    "mono_jav": "https://huggingface.co/datasets/Exqrch/IndonesianNMT/resolve/main/bt-id-jv.jv.txt?download=true",
+}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]  
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+def seacrowd_config_constructor(modifier, schema, version):
+    return SEACrowdConfig(
+            name=f"indonesiannmt-{modifier}_{schema}",
+            version=version,
+            description=f"indonesiannmt-{modifier} {schema} schema",
+            schema=f"{schema}",
+            subset_id="indonesiannmt",
+        )
+
+class IndonesianNMT(datasets.GeneratorBasedBuilder):
+    """IndonesianNMT consists of 4 parallel datasets and 2 monolingual datasets, 
+    all obtained synthetically from either gpt-3.5-turbo or text-davinci-003"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = (
+        [SEACrowdConfig(
+            name=f"indonesiannmt_source",
+            version=_SOURCE_VERSION,
+            description=f"indonesiannmt source schema",
+            schema=f"source",
+            subset_id="indonesiannmt",
+        )] + 
+        [SEACrowdConfig(
+            name=f"indonesiannmt_seacrowd_t2t",
+            version=_SEACROWD_VERSION,
+            description=f"indonesiannmt seacrowd_t2t schema",
+            schema=f"seacrowd_t2t",
+            subset_id="indonesiannmt",
+        )] +
+        [seacrowd_config_constructor(x, 'source', _SOURCE_VERSION) for x in ['mono_ind', 'mono_jav', 'parallel_ind_jav', 'parallel_ind_min', 'parallel_ind_sun', 'parallel_ind_ban']]
+        + [seacrowd_config_constructor(x, 'seacrowd_t2t', _SEACROWD_VERSION) for x in ['mono_ind', 'mono_jav', 'parallel_ind_jav', 'parallel_ind_min', 'parallel_ind_sun', 'parallel_ind_ban']])
+
+    DEFAULT_CONFIG_NAME = "indonesiannmt_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "lang_1": datasets.Value("string"),
+                    "lang_2": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "seacrowd_t2t":
+            features = schemas.text_to_text.features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        # ex mono: indonesiannmt-mono_ind_source OR indonesiannmt-mono_ind_seacrowd_t2t
+        # ex para: indonesiannmt-parallel_ind_jav_source OR indonesiannmt-parallel_ind_jav_seacrowd_t2t
+        if self.config.name in ['indonesiannmt_source', 'indonesiannmt_seacrowd_t2t']:
+            path = dl_manager.download_and_extract(_URLS['parallel_ind_jav'])
+        else:         
+            mono_or_para = self.config.name.split('-')[1].split('_')[0]
+            target = ""
+            if mono_or_para == "mono":
+                target = '_'.join(self.config.name.split('-')[1].split('_')[:2])
+            elif mono_or_para == "parallel":
+                target = '_'.join(self.config.name.split('-')[1].split('_')[:3])
+            url = _URLS[target]
+            path = dl_manager.download_and_extract(url)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": path,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(filepath, encoding="utf-8") as f:
+            flag = True  
+            mono = True
+            if self.config.schema == "source":
+                for counter, row in enumerate(f):
+                    if mono and not row.startswith('Indonesian'):
+                        if row.strip() != "":
+                            yield (
+                                counter,
+                                {
+                                    "id": str(counter),
+                                    "text_1": row.strip(),
+                                    "text_2": None,
+                                    "lang_1": None,
+                                    "lang_2": None,
+                                },
+                            )
+                    else:
+                        mono = False 
+                        if flag:
+                            src, tgt = row.split('\t')
+                            flag = False
+                        else:
+                            if row.strip() != "":
+                                yield(
+                                    counter,
+                                    {
+                                        "id": str(counter),
+                                        "text_1": row.split('\t')[0].strip(),
+                                        "text_2": row.split('\t')[1].strip(),
+                                        "lang_1": src,
+                                        "lang_2": tgt,
+                                    }
+                                )
+            else:
+                for counter, row in enumerate(f):
+                    if mono and not row.startswith('Indonesian'):
+                        if row.strip() != "":
+                            yield (
+                                counter,
+                                {
+                                    "id": str(counter),
+                                    "text_1": row.strip(),
+                                    "text_2": None,
+                                    "text_1_name": None,
+                                    "text_2_name": None,
+                                },
+                            )
+                    else:
+                        mono = False 
+                        if flag:
+                            src, tgt = row.split('\t')
+                            flag = False
+                        else:
+                            if row.strip() != "":
+                                yield(
+                                    counter,
+                                    {
+                                        "id": str(counter),
+                                        "text_1": row.split('\t')[0].strip(),
+                                        "text_2": row.split('\t')[1].strip(),
+                                        "text_1_name": src,
+                                        "text_2_name": tgt,
+                                    }
+                                )
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/templates/template.py
+++ b/templates/template.py
@@ -19,7 +19,7 @@ This template serves as a starting point for contributing a dataset to the SEACr
 When modifying it for your dataset, look for TODO items that offer specific instructions.
 
 Full documentation on writing dataset loading scripts can be found here:
-https://huggingface.co/docs/datasets/add_dataset.html
+https://huggingface.co/docs/hub/datasets-adding
 
 To create a dataset loading script you will create a class and implement 3 methods:
   * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.


### PR DESCRIPTION
Closes #338 

### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/indonesiannmt/indonesiannmt.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
