### PR TITLE
Related #157 | Add imqa schema and VISUAL_QUESTION_ANSWERING task

### DIFF
--- a/seacrowd/utils/constants.py
+++ b/seacrowd/utils/constants.py
@@ -10,6 +10,7 @@ from seacrowd.utils.schemas import (
     pairs_features_score,
     pairs_multi_features,
     qa_features,
+    imqa_features,
     seq_label_features,
     speech2speech_features,
     speech_features,
@@ -117,6 +118,7 @@ class Tasks(Enum):
 
     # ImageText
     IMAGE_CAPTIONING = "IC"
+    VISUAL_QUESTION_ANSWERING = "VQA"
     SIGN_LANGUAGE_RECOGNITION = "SLR"
     STYLIZED_IMAGE_CAPTIONING = "SIC"
     VISUALLY_GROUNDED_REASONING = "VGR"
@@ -266,6 +268,7 @@ TASK_TO_SCHEMA = {
     Tasks.SPEECH_LANGUAGE_IDENTIFICATION: "SPEECH",
     Tasks.SPEECH_EMOTION_RECOGNITION: "SPEECH",
     Tasks.SPEECH_EMOTION_RECOGNITION_MULTILABEL: "SPEECH_MULTI",
+    Tasks.VISUAL_QUESTION_ANSWERING: "IMQA",
     Tasks.IMAGE_CAPTIONING: "IMTEXT",
     Tasks.SIGN_LANGUAGE_RECOGNITION: "IMTEXT",
     Tasks.STYLIZED_IMAGE_CAPTIONING: "IMTEXT",
@@ -300,6 +303,7 @@ SCHEMA_TO_FEATURES = {
     "SPEECH": speech_features(),
     "SPEECH_MULTI": speech_multi_features(),
     "IMTEXT": image_text_features(),
+    "IMQA": imqa_features,
     "VIDTEXT": video_features,
     "TOD": tod_features,
 }

--- a/seacrowd/utils/schemas/__init__.py
+++ b/seacrowd/utils/schemas/__init__.py
@@ -5,6 +5,7 @@ from .pairs import features as pairs_features
 from .pairs import features_with_continuous_label as pairs_features_score
 from .pairs_multilabel import features as pairs_multi_features
 from .qa import features as qa_features
+from .imqa import features as imqa_features
 from .self_supervised_pretraining import features as ssp_features
 from .seq_label import features as seq_label_features
 from .speech import features as speech_features
@@ -25,6 +26,7 @@ __all__ = [
     "pairs_features_score",
     "pairs_multi_features",
     "qa_features",
+    "imqa_features",
     "ssp_features",
     "seq_label_features",
     "speech_features",

--- a/seacrowd/utils/schemas/imqa.py
+++ b/seacrowd/utils/schemas/imqa.py
@@ -1,0 +1,27 @@
+"""
+Image Question Answering Schema
+"""
+import datasets
+
+features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "question_id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "questions": datasets.Sequence(datasets.Value("string")),
+        "type": datasets.Value("string"),
+        "choices": datasets.Sequence(datasets.Value("string")),
+        "context": datasets.Value("string"),
+        "answer": datasets.Sequence(datasets.Value("string")),
+        "image_paths": datasets.Sequence(datasets.Value("string")),
+
+        # the schema of 'meta' aren't specified either to allow some flexibility
+        "meta": {}
+
+        # notes on how to use this field of 'meta'
+        # you can choose two of options:
+        # 1. defining as empty dict if you don't think it's usable in `_generate_examples`, or
+        # 2. defining meta as dict of key with intended colname meta and its val with dataset.Features class
+        #    in `_info` Dataloader method then populate it with the values in `_general_examples` Dataloader method
+    }
+)


### PR DESCRIPTION
Relate issue #157 and PR [302](https://github.com/SEACrowd/seacrowd-datahub/pull/302)

- Created imqa schema for visual question answering;
- Add VISUAL_QUESTION_ANSWERING task

Schema features:


features = datasets.Features(
    {
        "id": datasets.Value("string"),
        "question_id": datasets.Value("string"),
        "document_id": datasets.Value("string"),
        "questions": datasets.Sequence(datasets.Value("string")),
        "type": datasets.Value("string"),
        "choices": datasets.Sequence(datasets.Value("string")),
        "context": datasets.Value("string"),
        "answer": datasets.Sequence(datasets.Value("string")),
        "image_paths": datasets.Sequence(datasets.Value("string")),
        # the schema of 'meta' aren't specified either to allow some flexibility
        "meta": {}
        # notes on how to use this field of 'meta'
        # you can choose two of options:
        # 1. defining as empty dict if you don't think it's usable in `_generate_examples`, or
        # 2. defining meta as dict of key with intended colname meta and its val with dataset.Features class
        #    in `_info` Dataloader method then populate it with the values in `_general_examples` Dataloader method
    }
)