### PR TITLE
Closes #361 | Create dataset loader for Thai-Lao Parallel Corpus

### DIFF
--- a/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
+++ b/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils import schemas
+
+import pandas as pd
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{,
+  author    = {},
+  title     = {},
+  journal   = {},
+  volume    = {},
+  year      = {},
+  url       = {},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "tha_lao_embassy_parcor"
+
+_DESCRIPTION = """\
+Thai-Lao Parallel Corpus contains equivalent Thai and Lao sentence pairs \
+derived from the website of the Royal Thai Embassy in Vientiane, Laos.
+"""
+
+_HOMEPAGE = "https://github.com/PyThaiNLP/Thai-Lao-Parallel-Corpus/tree/master"
+_LANGUAGES = ["tha", "lao"]
+_LICENSE = Licenses.CC0_1_0.value
+
+_LOCAL = False
+_URLS = {
+    _DATASETNAME: "https://github.com/PyThaiNLP/Thai-Lao-Parallel-Corpus/raw/master/vientiane-thaiembassy-sent.csv"
+}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION] 
+_SOURCE_VERSION = "0.7.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+
+class ThaLaoEmbassyParcor(datasets.GeneratorBasedBuilder):
+    """Thai-Lao Parallel Corpus contains equivalent Thai and Lao sentence pairs \
+    derived from the website of the Royal Thai Embassy in Vientiane, Laos."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    SEACROWD_SCHEMA_NAME = "t2t"
+
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=f"{_DATASETNAME}",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+               {
+                   "lao_sent": datasets.Value("string"),
+                   "thai_sent": datasets.Value("string"),
+               }
+            )
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        filename = dl_manager.download(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(filename),
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        dataset = pd.read_csv(filepath)
+
+        if self.config.schema == "source":
+            for i, row in dataset.iterrows():
+                yield i, {
+                    "lao_sent": row["lao_sent"],
+                    "thai_sent": row["thai_sent"]
+                }
+
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            for i, row in dataset.iterrows():
+                yield i, {
+                    "id": i,
+                    "text_1": row["lao_sent"],
+                    "text_2": row["thai_sent"],
+                    "text_1_name": "lao",
+                    "text_2_name": "tha",
+                }
+
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
+++ b/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
@@ -26,18 +26,9 @@ from seacrowd.utils import schemas
 import pandas as pd
 
 # TODO: Add BibTeX citation
-_CITATION = """\
-@article{,
-  author    = {},
-  title     = {},
-  journal   = {},
-  volume    = {},
-  year      = {},
-  url       = {},
-  doi       = {},
-  biburl    = {},
-  bibsource = {}
-}
+_CITATION = """
+Wannaphong Phatthiyaphaibun. (2021). PyThaiNLP/Thai-Lao-Parallel-Corpus: 
+Thai Lao Parallel corpus v0.7 (v0.7). Zenodo. https://doi.org/10.5281/zenodo.5807093
 """
 
 _DATASETNAME = "tha_lao_embassy_parcor"
@@ -62,7 +53,7 @@ _SEACROWD_VERSION = "1.0.0"
 
 
 
-class ThaLaoEmbassyParcor(datasets.GeneratorBasedBuilder):
+class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
     """Thai-Lao Parallel Corpus contains equivalent Thai and Lao sentence pairs \
     derived from the website of the Royal Thai Embassy in Vientiane, Laos."""
 
@@ -144,5 +135,3 @@ class ThaLaoEmbassyParcor(datasets.GeneratorBasedBuilder):
                     "text_2_name": "tha",
                 }
 
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
+++ b/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
@@ -24,7 +24,6 @@ from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import Licenses, Tasks
 
-# TODO: Add BibTeX citation
 _CITATION = """
 Wannaphong Phatthiyaphaibun. (2021). PyThaiNLP/Thai-Lao-Parallel-Corpus: \
 Thai Lao Parallel corpus v0.7 (v0.7). Zenodo \

--- a/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
+++ b/seacrowd/sea_datasets/tha_lao_embassy_parcor/tha_lao_embassy_parcor.py
@@ -18,18 +18,17 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import datasets
-
-from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
-from seacrowd.utils import schemas
-
 import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
 
 # TODO: Add BibTeX citation
 _CITATION = """
-Wannaphong Phatthiyaphaibun. (2021). PyThaiNLP/Thai-Lao-Parallel-Corpus: 
-Thai Lao Parallel corpus v0.7 (v0.7). Zenodo. https://doi.org/10.5281/zenodo.5807093
-"""
+Wannaphong Phatthiyaphaibun. (2021). PyThaiNLP/Thai-Lao-Parallel-Corpus: \
+Thai Lao Parallel corpus v0.7 (v0.7). Zenodo \
+https://doi.org/10.5281/zenodo.5807093"""
 
 _DATASETNAME = "tha_lao_embassy_parcor"
 
@@ -43,14 +42,11 @@ _LANGUAGES = ["tha", "lao"]
 _LICENSE = Licenses.CC0_1_0.value
 
 _LOCAL = False
-_URLS = {
-    _DATASETNAME: "https://github.com/PyThaiNLP/Thai-Lao-Parallel-Corpus/raw/master/vientiane-thaiembassy-sent.csv"
-}
+_URLS = {_DATASETNAME: "https://github.com/PyThaiNLP/Thai-Lao-Parallel-Corpus/raw/master/vientiane-thaiembassy-sent.csv"}
 
-_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION] 
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
 _SOURCE_VERSION = "0.7.0"
 _SEACROWD_VERSION = "1.0.0"
-
 
 
 class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
@@ -60,7 +56,6 @@ class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
     SEACROWD_SCHEMA_NAME = "t2t"
-
 
     BUILDER_CONFIGS = [
         SEACrowdConfig(
@@ -82,13 +77,12 @@ class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
         if self.config.schema == "source":
             features = datasets.Features(
-               {
-                   "lao_sent": datasets.Value("string"),
-                   "thai_sent": datasets.Value("string"),
-               }
+                {
+                    "lao_sent": datasets.Value("string"),
+                    "thai_sent": datasets.Value("string"),
+                }
             )
         elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
             features = schemas.text2text_features
@@ -120,10 +114,7 @@ class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
 
         if self.config.schema == "source":
             for i, row in dataset.iterrows():
-                yield i, {
-                    "lao_sent": row["lao_sent"],
-                    "thai_sent": row["thai_sent"]
-                }
+                yield i, {"lao_sent": row["lao_sent"], "thai_sent": row["thai_sent"]}
 
         elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
             for i, row in dataset.iterrows():
@@ -134,4 +125,3 @@ class ThaLaoEmbassyParcorDataset(datasets.GeneratorBasedBuilder):
                     "text_1_name": "lao",
                     "text_2_name": "tha",
                 }
-


### PR DESCRIPTION
Closes #361 
### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
