### PR TITLE
Improvement: Workflow Message to Mention Assignee in Staled Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,9 +6,6 @@
 name: Mark stale issues and pull requests
 
 on:
-  push:
-    # Sequence of patterns matched against refs/heads
-    branches: workflow_test_mention_assignee
   schedule:
   - cron: '20 1 * * *'
 
@@ -27,9 +24,9 @@ jobs:
         stale-issue-message: 'Hi @${assignee}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
         stale-pr-message: 'Hi @${assignee} & @${author}, may I know if you are still working on this PR?'
         stale-issue-label: 'staled-issue'
-        days-before-stale: 1
+        stale-pr-label: 'need-fu-pr'
+        days-before-stale: 14
         days-before-close: -1
-        debug-only: true
         include-only-assigned: true
         exempt-issue-labels: 'in-progress,pr-ready'
-        operations-per-run: 100
+        operations-per-run: 200

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
         stale-issue-message: 'Hi @${assignee}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
         stale-pr-message: 'Hi @${assignee} & @${author}, may I know if you are still working on this PR?'
         stale-issue-label: 'staled-issue'
-        days-before-stale: 14
+        days-before-stale: 1
         days-before-close: -1
         debug-only: true
         include-only-assigned: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,10 +21,12 @@ jobs:
     - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Hi, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
+        stale-issue-message: 'Hi @${assignee}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
+        stale-pr-message: 'Hi @${assignee} & @${author}, may I know if you are still working on this PR?'
         stale-issue-label: 'staled-issue'
         days-before-stale: 14
         days-before-close: -1
+        debug-only: true
         include-only-assigned: true
         exempt-issue-labels: 'in-progress,pr-ready'
         operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@
 name: Mark stale issues and pull requests
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: '20 1 * * *'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,9 @@
 name: Mark stale issues and pull requests
 
 on:
-  workflow_dispatch:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches: workflow_test_mention_assignee
   schedule:
   - cron: '20 1 * * *'
 


### PR DESCRIPTION
Hi @holylovenia @SamuelCahyawijaya, I'm proposing an improvement in Workflow where you can mention the assignee in Staled Issue. I happened to see [this PR in Stale Actions Repo](https://github.com/microsoft/pylance-release/pull/4054/files) and trying to implement it in our reminder message from GH actions.

PS.: the expected output (comments on actual actions) can't be seen on `debug-mode`; that's why I'm trying to merge this to test the actual message, whether it's adhering to the expectations. Feel free to reject this if you have any concerns on this. Thanks