### PR TITLE
Fix: Workflow Assignee Mention

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
       
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hi @${{github.event.issue.assignee.login}}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
-        stale-pr-message: 'Hi @${{join(github.event.issue.assignees.*.login, ", @") }} & @${{github.event.issue.user.login}}, may I know if you are still working on this PR?'
+        stale-pr-message: 'Hi @${{join(github.event.issue.assignees.*.login, " @") }} & @${{github.event.issue.user.login}}, may I know if you are still working on this PR?'
         stale-issue-label: 'staled-issue'
         stale-pr-label: 'need-fu-pr'
         days-before-stale: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,9 +20,10 @@ jobs:
     steps:
     - uses: actions/stale@v8
       with:
+      
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Hi @${assignee}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
-        stale-pr-message: 'Hi @${assignee} & @${author}, may I know if you are still working on this PR?'
+        stale-issue-message: 'Hi @${{github.event.issue.assignee.login}}, may I know if you are still working on this issue? Please let @holylovenia @SamuelCahyawijaya @sabilmakbar know if you need any help.'
+        stale-pr-message: 'Hi @${{join(github.event.issue.assignees.*.login, ", @") }} & @${{github.event.issue.user.login}}, may I know if you are still working on this PR?'
         stale-issue-label: 'staled-issue'
         stale-pr-label: 'need-fu-pr'
         days-before-stale: 14


### PR DESCRIPTION
After re-reading, actually the previously implemented workflow uses another custom workflow imported to make `assignees` and `author` uname construction works.
<img width="468" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/69744460/2a9a1c5f-f593-4220-a5bc-efe64155e34e">

which returns unexpected commenting behavior in the new stale
<img width="925" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/69744460/ef0ed096-ab2f-41ca-bf0a-222e214ab32d">


Hence, from the subsequent comment in the SS, I found [this](https://github.com/microsoft/pylance-release/pull/4054#discussion_r1131864892) reference of author and assignees using github internal variable (which is supposedly works since it works in the Issue & PR level and coming from github internal vars)
<img width="793" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/69744460/ebbbdd9e-3fb7-473e-8333-5fe24abeaf51">

