### PR TITLE
Closes #51 | Add id_sentiment_analysis dataloader

### DIFF
--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -41,7 +41,7 @@ This dataset was developed in Cloud Experience Research Group, Gadjah Mada Unive
 There is no further explanation of the dataset. Contributor found this dataset after skimming through "Sentiment analysis of Indonesian datasets based on a hybrid deep-learning strategy" (Lin CH and Nuha U, 2023).
 """
 
-_HOMEPAGE = "https://github.com/ridife/dataset-idsa/blob/master/Indonesian%20Sentiment%20Twitter%20Dataset%20Labeled.csv"
+_HOMEPAGE = "https://ridi.staff.ugm.ac.id/2019/03/06/indonesia-sentiment-analysis-dataset/"
 
 _LANGUAGES = ["ind"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = """\
+"""
+
+_DATASETNAME = "id_sentiment_analysis"
+
+_DESCRIPTION = """\
+This dataset consists of 10806 labeled Indonesian tweets with their corresponding sentiment analysis: positive, negative, and neutral, up to 2019.
+This dataset was developed in Cloud Experience Research Group, Gadjah Mada University.
+There is no further explanation of the dataset. Contributor found this dataset after skimming through "Sentiment analysis of Indonesian datasets based on a hybrid deep-learning strategy" (Lin CH and Nuha U, 2023).
+"""
+
+_HOMEPAGE = "https://github.com/ridife/dataset-idsa/blob/master/Indonesian%20Sentiment%20Twitter%20Dataset%20Labeled.csv"
+
+_LANGUAGES = ["ind"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LICENSE = Licenses.CC_BY_NC_4_0.value
+
+_LOCAL = False
+
+_URLS = {
+    _DATASETNAME: "https://raw.githubusercontent.com/ridife/dataset-idsa/master/Indonesian%20Sentiment%20Twitter%20Dataset%20Labeled.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]
+_SUPPORTED_SCHEMA_STRINGS = [f"seacrowd_{str(TASK_TO_SCHEMA[task]).lower()}" for task in _SUPPORTED_TASKS]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class IdSentimentAnalysis(datasets.GeneratorBasedBuilder):
+    """This dataset consists of 10806 labeled Indonesian tweets with their corresponding sentiment analysis: positive, negative, and neutral, up to 2019."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        ),
+    ]
+
+    seacrowd_schema_config: list[SEACrowdConfig] = []
+
+    for seacrowd_schema in _SUPPORTED_SCHEMA_STRINGS:
+
+        seacrowd_schema_config.append(
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{seacrowd_schema}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {seacrowd_schema} schema",
+                schema=f"{seacrowd_schema}",
+                subset_id=f"{_DATASETNAME}",
+            )
+        )
+
+    BUILDER_CONFIGS.extend(seacrowd_schema_config)
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "sentimen": datasets.Value("int32"),
+                    "Tweet": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SENTIMENT_ANALYSIS]).lower()}":
+            features = schemas.text_features(label_names=[1, -1, 0])
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        path = dl_manager.download_and_extract(_URLS[_DATASETNAME])
+
+        print(path)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "path": path,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, path: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        idx = 0
+
+        if self.config.schema == "source":
+            df = pd.read_csv(path, delimiter="\t")
+
+            for _, row in df.iterrows():
+                yield idx, row.to_dict()
+                idx += 1
+
+        elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SENTIMENT_ANALYSIS]).lower()}":
+            df = pd.read_csv(path, delimiter="\t")
+
+            df["id"] = df.index
+            df.rename(columns={"sentimen": "label"}, inplace=True)
+            df.rename(columns={"Tweet": "text"}, inplace=True)
+
+            for _, row in df.iterrows():
+                yield idx, row.to_dict()
+                idx += 1
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -23,6 +23,14 @@ from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
 
 _CITATION = """\
+@misc{ridife2019idsa,
+  author = {Fe, Ridi},
+  title = {Indonesia Sentiment Analysis Dataset},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/ridife/dataset-idsa}}
+}
 """
 
 _DATASETNAME = "id_sentiment_analysis"

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -45,7 +45,7 @@ _HOMEPAGE = "https://github.com/ridife/dataset-idsa/blob/master/Indonesian%20Sen
 
 _LANGUAGES = ["ind"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 
-_LICENSE = Licenses.CC_BY_NC_4_0.value
+_LICENSE = Licenses.UNKNOWN.value
 
 _LOCAL = False
 

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -141,6 +141,8 @@ class IdSentimentAnalysis(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source":
             df = pd.read_csv(path, delimiter="\t")
 
+            df.rename(columns={"Tweet": "tweet"}, inplace=True)
+
             for _, row in df.iterrows():
                 yield idx, row.to_dict()
                 idx += 1

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -29,7 +29,7 @@ _CITATION = """\
   year = {2019},
   publisher = {GitHub},
   journal = {GitHub repository},
-  howpublished = {\url{https://github.com/ridife/dataset-idsa}}
+  howpublished = {\\url{https://github.com/ridife/dataset-idsa}}
 }
 """
 
@@ -77,7 +77,7 @@ class IdSentimentAnalysis(datasets.GeneratorBasedBuilder):
         ),
     ]
 
-    seacrowd_schema_config: list[SEACrowdConfig] = []
+    seacrowd_schema_config: List[SEACrowdConfig] = []
 
     for seacrowd_schema in _SUPPORTED_SCHEMA_STRINGS:
 

--- a/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
+++ b/seacrowd/sea_datasets/id_sentiment_analysis/id_sentiment_analysis.py
@@ -116,8 +116,6 @@ class IdSentimentAnalysis(datasets.GeneratorBasedBuilder):
 
         path = dl_manager.download_and_extract(_URLS[_DATASETNAME])
 
-        print(path)
-
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,

--- a/seacrowd/sea_datasets/indo_story_cloze/indo_story_cloze.py
+++ b/seacrowd/sea_datasets/indo_story_cloze/indo_story_cloze.py
@@ -1,0 +1,179 @@
+import csv
+import random
+import string
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """
+@inproceedings{koto-etal-2022-cloze,
+    title = "Cloze Evaluation for Deeper Understanding of Commonsense Stories in {I}ndonesian",
+    author = "Koto, Fajri  and
+      Baldwin, Timothy  and
+      Lau, Jey Han",
+    editor = "Bosselut, Antoine  and
+      Li, Xiang  and
+      Lin, Bill Yuchen  and
+      Shwartz, Vered  and
+      Majumder, Bodhisattwa Prasad  and
+      Lal, Yash Kumar  and
+      Rudinger, Rachel  and
+      Ren, Xiang  and
+      Tandon, Niket  and
+      Zouhar, Vil{\'e}m",
+    booktitle = "Proceedings of the First Workshop on Commonsense Representation and Reasoning (CSRR 2022)",
+    month = may,
+    year = "2022",
+    address = "Dublin, Ireland",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.csrr-1.2",
+    doi = "10.18653/v1/2022.csrr-1.2",
+    pages = "8--16",
+}
+"""
+
+_DATASETNAME = "indo_story_cloze"
+
+_DESCRIPTION = """
+A Story Cloze Test framework in Indonesian. A story in our dataset consists of four-sentence premise, one-sentence
+correct ending, and one-sentence incorrect ending. In total, we have created 2,325 Indonesian stories with the
+train/dev/test split 1,000/200/1,135.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/indolem/indo_story_cloze"
+
+_LANGUAGES = ["ind"]
+
+_LICENSE = Licenses.CC_BY_SA_4_0.value
+
+_LOCAL = False
+
+_URLS = {
+    _DATASETNAME: {
+        "train": "https://huggingface.co/datasets/indolem/indo_story_cloze/resolve/main/train.csv",
+        "dev": "https://huggingface.co/datasets/indolem/indo_story_cloze/resolve/main/dev.csv",
+        "test": "https://huggingface.co/datasets/indolem/indo_story_cloze/resolve/main/test.csv",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.COMMONSENSE_REASONING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class IndoStoryClozeDataset(datasets.GeneratorBasedBuilder):
+    """IndoStoryCloze is a Story Cloze dataset in Indonesian."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_qa",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema="seacrowd_qa",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "sentence-1": datasets.Value("string"),
+                    "sentence-2": datasets.Value("string"),
+                    "sentence-3": datasets.Value("string"),
+                    "sentence-4": datasets.Value("string"),
+                    "correct_ending": datasets.Value("string"),
+                    "incorrect_ending": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "seacrowd_qa":
+            features = schemas.qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": data_dir, "split": "train"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_dir, "split": "test"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": data_dir, "split": "dev"},
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        if self.config.schema == "source":
+            data = csv.DictReader(open(filepath[split], newline="", encoding="utf-8"))
+            for i, row in enumerate(data):
+                yield i, {
+                    "sentence-1": row["Kalimat-1"],
+                    "sentence-2": row["Kalimat-2"],
+                    "sentence-3": row["Kalimat-3"],
+                    "sentence-4": row["Kalimat-4"],
+                    "correct_ending": row["Correct Ending"],
+                    "incorrect_ending": row["Incorrect Ending"],
+                }
+
+        elif self.config.schema == "seacrowd_qa":
+            data = csv.DictReader(open(filepath[split], newline="", encoding="utf-8"))
+
+            def build_question(line):
+                # Concatenate the 4 sentences, this can either be the question of the context. Set is as question for
+                # now. Some sentences do not have punctuation, hence adding . before concatenation.
+                sentences = []
+                for k in ["Kalimat-1", "Kalimat-2", "Kalimat-3", "Kalimat-4"]:
+                    if line[k].strip()[-1] not in string.punctuation:
+                        sentences.append(line[k] + ".")
+                    else:
+                        sentences.append(line[k])
+                return " ".join(sentences)
+
+            for i, row in enumerate(data):
+                yield i, {
+                    "id": str(i),
+                    "question_id": str(i),
+                    "document_id": str(i),
+                    "question": build_question(row),
+                    "type": "multiple_choice",
+                    # Reorder choices based on the randomly generated labels, avoiding correct answer at the same order.
+                    "choices": [row["Correct Ending"], row["Incorrect Ending"]] if random.randint(0, 1) == 0 else [row["Incorrect Ending"], row["Correct Ending"]],
+                    "context": "",
+                    "answer": [row["Correct Ending"]],
+                    "meta": {},
+                }


### PR DESCRIPTION
Closes [#51](https://github.com/SEACrowd/seacrowd-datahub/issues/51)

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
