### PR TITLE
Closes #278 | Add mywsl2023 dataloader

### DIFF
--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -108,7 +108,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
             )
 
         elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SIGN_LANGUAGE_RECOGNITION]).lower()}":
-            features = schemas.image_text_features(label_names=[""])
+            features = schemas.image_text_features(label_names=[])
 
         else:
             raise ValueError(f"Invalid config: {self.config.name}")
@@ -165,7 +165,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                     "texts": os.path.basename(image_folder_path),
                     "metadata": {
                         "context": "Malaysian Sign Language (XML)",
-                        "labels": [""],
+                        "labels": [],
                     },
                 }
                 idx += 1

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -68,7 +68,11 @@ _URLS = {_DATASETNAME: "https://data.mendeley.com/public-files/datasets/zvk55p7k
 _SUPPORTED_TASKS = [Tasks.SIGN_LANGUAGE_RECOGNITION]
 _SUPPORTED_SCHEMA_STRINGS = [f"seacrowd_{str(TASK_TO_SCHEMA[task]).lower()}" for task in _SUPPORTED_TASKS]
 
-_SPLITS = ["train", "test"]
+_SPLITS = [datasets.Split.TRAIN, datasets.Split.TEST]
+_SPLIT_NAMES = {
+    datasets.Split.TRAIN: "train",
+    datasets.Split.TEST: "test",
+}
 
 _SOURCE_VERSION = "1.0.0"
 
@@ -147,7 +151,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                 datasets.SplitGenerator(
                     name=split,
                     gen_kwargs={
-                        "path": os.path.join(path, "MyWSL2023 RAW DATA", split),
+                        "path": os.path.join(path, "MyWSL2023 RAW DATA", _SPLIT_NAMES[split]),
                     },
                 )
             )

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -34,16 +34,6 @@ doi = {https://doi.org/10.1016/j.dib.2023.109338},
 url = {https://www.sciencedirect.com/science/article/pii/S2352340923004560},
 author = {Rina Tasia Johari and Rizauddin Ramli and Zuliani Zulkoffli and Nizaroyani Saibani},
 keywords = {Dataset, Hand gestures, Sign language, Image data},
-abstract = {Deaf and hard-of-hearing individuals use sign language as a means of communication. However, those around them,
-especially family members like the children of deaf adults, may face communication challenges if they are unfamiliar with sign
-language. This issue has prompted numerous researchers to conduct studies on sign language translation and recognition. However,
-there is currently no publicly available dataset specifically for Malaysian sign language. This article introduces an image dataset
-of the Malaysian Sign Language (MySL) hand gestures used in everyday situations. The dataset, named MyWSL2023, comprises 3,500 images
-of ten static Malaysian sign language words collected from five participants (two males and three females) aged between 20 and 21
-years old. The data collection took place indoors under normal lighting conditions. The MyWSL2023 dataset, which has been made freely
-accessible to all researchers, serves as a valuable resource for not only investigating and developing automated systems for
-hearing-impaired and deaf individuals but also gesture and sign language recognition using vision-based methods. The dataset can be
-accessed for free at https://data.mendeley.com/datasets/zvk55p7ktd.}
 }
 """
 

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -59,10 +59,6 @@ _SUPPORTED_TASKS = [Tasks.SIGN_LANGUAGE_RECOGNITION]
 _SUPPORTED_SCHEMA_STRINGS = [f"seacrowd_{str(TASK_TO_SCHEMA[task]).lower()}" for task in _SUPPORTED_TASKS]
 
 _SPLITS = [datasets.Split.TRAIN, datasets.Split.TEST]
-_SPLIT_NAMES = {
-    datasets.Split.TRAIN: "train",
-    datasets.Split.TEST: "test",
-}
 
 _LABELS = ["air", "demam", "dengar", "makan", "minum", "salah", "saya", "senyap", "tidur", "waktu"]
 
@@ -143,7 +139,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                 datasets.SplitGenerator(
                     name=split,
                     gen_kwargs={
-                        "path": os.path.join(path, "MyWSL2023 RAW DATA", _SPLIT_NAMES[split]),
+                        "path": os.path.join(path, "MyWSL2023 RAW DATA", split._name),
                     },
                 )
             )
@@ -163,7 +159,6 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                     "image_paths": [os.path.join(image_folder_path, image_path) for image_path in image_paths],
                     "texts": os.path.basename(image_folder_path),
                 }
-                idx += 1
 
             elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SIGN_LANGUAGE_RECOGNITION]).lower()}":
                 yield idx, {
@@ -175,7 +170,6 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                         "labels": [os.path.basename(image_folder_path)],
                     },
                 }
-                idx += 1
 
             else:
                 raise ValueError(f"Invalid config: {self.config.name}")

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -23,13 +23,27 @@ from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
 
 _CITATION = """\
-@dataset{Johari2023,
-  author = {Johari, Rina},
-  title = {MyWSL2023},
-  year = {2023},
-  publisher = {Mendeley Data},
-  version = {V1},
-  doi = {10.17632/zvk55p7ktd.1}
+@article{JOHARI2023109338,
+title = {MyWSL: Malaysian words sign language dataset},
+journal = {Data in Brief},
+volume = {49},
+pages = {109338},
+year = {2023},
+issn = {2352-3409},
+doi = {https://doi.org/10.1016/j.dib.2023.109338},
+url = {https://www.sciencedirect.com/science/article/pii/S2352340923004560},
+author = {Rina Tasia Johari and Rizauddin Ramli and Zuliani Zulkoffli and Nizaroyani Saibani},
+keywords = {Dataset, Hand gestures, Sign language, Image data},
+abstract = {Deaf and hard-of-hearing individuals use sign language as a means of communication. However, those around them,
+especially family members like the children of deaf adults, may face communication challenges if they are unfamiliar with sign
+language. This issue has prompted numerous researchers to conduct studies on sign language translation and recognition. However,
+there is currently no publicly available dataset specifically for Malaysian sign language. This article introduces an image dataset
+of the Malaysian Sign Language (MySL) hand gestures used in everyday situations. The dataset, named MyWSL2023, comprises 3,500 images
+of ten static Malaysian sign language words collected from five participants (two males and three females) aged between 20 and 21
+years old. The data collection took place indoors under normal lighting conditions. The MyWSL2023 dataset, which has been made freely
+accessible to all researchers, serves as a valuable resource for not only investigating and developing automated systems for
+hearing-impaired and deaf individuals but also gesture and sign language recognition using vision-based methods. The dataset can be
+accessed for free at https://data.mendeley.com/datasets/zvk55p7ktd.}
 }
 """
 

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -128,8 +128,6 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
 
         path = dl_manager.download_and_extract(_URLS[_DATASETNAME])
 
-        print(path)
-
         for split in _SPLITS:
             split_generators.append(
                 datasets.SplitGenerator(

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -161,10 +161,9 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, path: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
 
-        idx = 0
         image_folder_paths = [os.path.join(path, folder) for folder in os.listdir(path)]
 
-        for image_folder_path in image_folder_paths:
+        for idx, image_folder_path in enumerate(image_folder_paths):
             image_paths = os.listdir(image_folder_path)
 
             if self.config.schema == "source":

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -64,6 +64,8 @@ _SPLIT_NAMES = {
     datasets.Split.TEST: "test",
 }
 
+_LABELS = ["air", "demam", "dengar", "makan", "minum", "salah", "saya", "senyap", "tidur", "waktu"]
+
 _SOURCE_VERSION = "1.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
@@ -116,7 +118,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
             )
 
         elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SIGN_LANGUAGE_RECOGNITION]).lower()}":
-            features = schemas.image_text_features(label_names=[])
+            features = schemas.image_text_features(label_names=_LABELS)
 
         else:
             raise ValueError(f"Invalid config: {self.config.name}")
@@ -170,7 +172,7 @@ class MyWsl2023(datasets.GeneratorBasedBuilder):
                     "texts": os.path.basename(image_folder_path),
                     "metadata": {
                         "context": "Malaysian Sign Language (XML)",
-                        "labels": [],
+                        "labels": [os.path.basename(image_folder_path)],
                     },
                 }
                 idx += 1

--- a/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
+++ b/seacrowd/sea_datasets/mywsl2023/mywsl2023.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = """\
+@dataset{Johari2023,
+  author = {Johari, Rina},
+  title = {MyWSL2023},
+  year = {2023},
+  publisher = {Mendeley Data},
+  version = {V1},
+  doi = {10.17632/zvk55p7ktd.1}
+}
+"""
+
+_DATASETNAME = "mywsl2023"
+
+_DESCRIPTION = """\
+This dataset contains pictures of hand gestures corresponding to ten commonly-used Malaysian Sign Language (XML) words.
+Gestures are performed by five university students who belong to different ethnic groups and are proficient in XML.
+Each gesture class contains 350 instances.
+"""
+
+_HOMEPAGE = "https://data.mendeley.com/datasets/zvk55p7ktd/1"
+
+_LANGUAGES = ["xml"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LICENSE = Licenses.CC_BY_4_0.value
+
+_LOCAL = False
+
+_URLS = {_DATASETNAME: "https://data.mendeley.com/public-files/datasets/zvk55p7ktd/files/7f11b8a0-24e4-45df-af3d-e861f41435ea/file_downloaded"}
+
+_SUPPORTED_TASKS = [Tasks.SIGN_LANGUAGE_RECOGNITION]
+_SUPPORTED_SCHEMA_STRINGS = [f"seacrowd_{str(TASK_TO_SCHEMA[task]).lower()}" for task in _SUPPORTED_TASKS]
+
+_SPLITS = ["train", "test"]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class MyWsl2023(datasets.GeneratorBasedBuilder):
+    """This dataset contains pictures of hand gestures corresponding to ten commonly-used Malaysian Sign Language (XML) words."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    subset_id = _DATASETNAME
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{subset_id}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=subset_id,
+        )
+    ]
+
+    seacrowd_schema_config: list[SEACrowdConfig] = []
+
+    for seacrowd_schema in _SUPPORTED_SCHEMA_STRINGS:
+
+        seacrowd_schema_config.append(
+            SEACrowdConfig(
+                name=f"{subset_id}_{seacrowd_schema}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {seacrowd_schema} schema",
+                schema=f"{seacrowd_schema}",
+                subset_id=subset_id,
+            )
+        )
+
+    BUILDER_CONFIGS.extend(seacrowd_schema_config)
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "image_paths": datasets.Sequence(datasets.Value("string")),
+                    "texts": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SIGN_LANGUAGE_RECOGNITION]).lower()}":
+            features = schemas.image_text_features(label_names=[""])
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        split_generators = []
+
+        path = dl_manager.download_and_extract(_URLS[_DATASETNAME])
+
+        print(path)
+
+        for split in _SPLITS:
+            split_generators.append(
+                datasets.SplitGenerator(
+                    name=split,
+                    gen_kwargs={
+                        "path": os.path.join(path, "MyWSL2023 RAW DATA", split),
+                    },
+                )
+            )
+
+        return split_generators
+
+    def _generate_examples(self, path: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        idx = 0
+        image_folder_paths = [os.path.join(path, folder) for folder in os.listdir(path)]
+
+        for image_folder_path in image_folder_paths:
+            image_paths = os.listdir(image_folder_path)
+
+            if self.config.schema == "source":
+                yield idx, {
+                    "image_paths": [os.path.join(image_folder_path, image_path) for image_path in image_paths],
+                    "texts": os.path.basename(image_folder_path),
+                }
+                idx += 1
+
+            elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.SIGN_LANGUAGE_RECOGNITION]).lower()}":
+                yield idx, {
+                    "id": os.path.basename(image_folder_path),
+                    "image_paths": [os.path.join(image_folder_path, image_path) for image_path in image_paths],
+                    "texts": os.path.basename(image_folder_path),
+                    "metadata": {
+                        "context": "Malaysian Sign Language (XML)",
+                        "labels": [""],
+                    },
+                }
+                idx += 1
+
+            else:
+                raise ValueError(f"Invalid config: {self.config.name}")


### PR DESCRIPTION
Closes [#278](https://github.com/SEACrowd/seacrowd-datahub/issues/278)

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
