### PR TITLE
Closes #32 (High Prio) | Extend XL Sum Dataloaders to SEA Langs

### DIFF
--- a/seacrowd/sea_datasets/xl_sum/xl_sum.py
+++ b/seacrowd/sea_datasets/xl_sum/xl_sum.py
@@ -2,13 +2,13 @@ import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+import json
 import datasets
 
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks
+from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
 from seacrowd.utils import schemas
-import jsonlines
-from nltk.tokenize.treebank import TreebankWordDetokenizer
+
 
 _CITATION = """\
 @inproceedings{hasan2021xl,
@@ -21,21 +21,26 @@ _CITATION = """\
 """
 
 _LOCAL = False
-_LANGUAGES = ["ind", "eng"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_LANGUAGES = ["ind", "mya", "tha", "vie", "eng"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LANG_TO_DATASOURCE_LANG = {
+    "ind": "indonesian",
+    "mya": "burmese",
+    "vie": "vietnamese",
+    "tha": "thai"}
+
 _DATASETNAME = "xl_sum"
 
 _DESCRIPTION = """\
-XL-Sum is a large-scale multilingual summarization dataset that covers 45 languages including Indonesian text summarization.
-The dataset is based on article-summary pairs from BBC, is highly abstractive, concise, and of high quality, as indicated by human and intrinsic evaluation.
+XL-Sum, a comprehensive and diverse dataset comprising 1 million professionally annotated article-summary pairs from BBC, was extracted using a set of carefully designed heuristics.
+The dataset covers 44 languages ranging from low to high-resource, including 4 indigenous languages spoken in Southeast Asia region.
 """
 
 _HOMEPAGE = "https://github.com/csebuetnlp/xl-sum"
 
-_LICENSE = "CC-BY-NC-SA 4.0"
+_LICENSE = Licenses.CC_BY_NC_SA_4_0.value
 
-_URLS = {
-    _DATASETNAME: "https://huggingface.co/datasets/csebuetnlp/xlsum/resolve/main/data/indonesian_XLSum_v2.0.tar.bz2",
-}
+_URLS = "https://huggingface.co/datasets/csebuetnlp/xlsum/resolve/main/data/{}_XLSum_v{}.tar.bz2"
 
 _SUPPORTED_TASKS = [Tasks.SUMMARIZATION]
 
@@ -43,30 +48,60 @@ _SOURCE_VERSION = "2.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
 
+
+def construct_configs_on_langs() -> List[SEACrowdConfig]:
+    """
+    The function `construct_configs` constructs a list of SEACrowdConfig objects based on `_LANGUAGES` var, and returns the list.
+
+    output:
+        a list of `SEACrowdConfig` objects based on instantiated init variables
+    """
+
+    # set output var
+    config_list = []
+
+    # construct zipped arg for config instantiation
+    CONFIG_SUFFIXES_FOR_TASK = [TASK_TO_SCHEMA.get(task).lower() for task in _SUPPORTED_TASKS]
+    TASKS_AND_CONFIG_SUFFIX_PAIRS = list(zip(_SUPPORTED_TASKS, CONFIG_SUFFIXES_FOR_TASK))
+
+    # implement source schema
+    version, config_name_prefix = _SOURCE_VERSION, "source"
+    config_list += [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{_LANG}_{config_name_prefix}",
+            version=datasets.Version(version),
+            description=f"{_DATASETNAME} {config_name_prefix} schema for language code {_LANG}",
+            schema=f"{config_name_prefix}",
+            subset_id=_LANG,
+        )
+        #skip english lang
+        for _LANG in _LANGUAGES if _LANG != "eng"
+    ]
+
+    # implement SEACrowd schema
+    version, config_name_prefix = _SEACROWD_VERSION, "seacrowd"
+    for task_obj, config_name_suffix in TASKS_AND_CONFIG_SUFFIX_PAIRS:
+        config_list += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{_LANG}_{config_name_prefix}_{config_name_suffix}",
+                version=datasets.Version(version),
+                description=f"{_DATASETNAME} {config_name_prefix} schema for {task_obj.name} and language code {_LANG}",
+                schema=f"{config_name_prefix}_{config_name_suffix}",
+                subset_id=_LANG,
+            )
+            #skip english lang
+            for _LANG in _LANGUAGES if _LANG != "eng"
+        ]
+    return config_list
+
+
 class XLSum(datasets.GeneratorBasedBuilder):
     """XL-Sum is a large-scale multilingual summarization dataset that covers 45 languages including Indonesian text summarization. The dataset is based on article-summary pairs from BBC, is highly abstractive, concise, and of high quality, as indicated by human and intrinsic evaluation."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
-    BUILDER_CONFIGS = [
-        SEACrowdConfig(
-            name="xl_sum_source",
-            version=datasets.Version(_SOURCE_VERSION),
-            description="xl_sum source schema",
-            schema="source",
-            subset_id="xl_sum",
-        ),
-        SEACrowdConfig(
-            name="xl_sum_seacrowd_t2t",
-            version=datasets.Version(_SEACROWD_VERSION),
-            description="xl_sum Nusantara schema",
-            schema="seacrowd_t2t",
-            subset_id="xl_sum",
-        ),
-    ]
-
-    DEFAULT_CONFIG_NAME = "xl_sum_source"
+    BUILDER_CONFIGS = construct_configs_on_langs()
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -92,63 +127,58 @@ class XLSum(datasets.GeneratorBasedBuilder):
 
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
-        data_dir = Path(dl_manager.download_and_extract(_URLS[_DATASETNAME]))
+        lang = _LANG_TO_DATASOURCE_LANG[self.config.subset_id]
+        url = _URLS.format(lang, self.SOURCE_VERSION.version_str[:-2])
 
-        data_files = {
-            "train": "indonesian_train.jsonl",
-            "validation": "indonesian_val.jsonl",
-            "test": "indonesian_test.jsonl",
-        }
-
+        data_dir = dl_manager.download_and_extract(url)
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, data_files["train"]),
-                    "split": "train",
-                },
-            ),
-            datasets.SplitGenerator(
-                name=datasets.Split.VALIDATION,
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, data_files["validation"]),
-                    "split": "dev",
+                    "filepath": os.path.join(data_dir, lang + "_train.jsonl"),
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, data_files["test"]),
-                    "split": "test",
+                    "filepath": os.path.join(data_dir, lang + "_test.jsonl"),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, lang + "_val.jsonl"),
                 },
             ),
         ]
 
-    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
 
         if self.config.schema == "source":
-            with jsonlines.open(filepath) as f:
-                for each_data in f.iter():
+            with open(filepath, encoding="utf-8") as f:
+                for row in f:
+                    data = json.loads(row)
                     ex = {
-                        "id": each_data["id"],
-                        "url": each_data["url"],
-                        "title": each_data["title"],
-                        "text": each_data["text"],
-                        "summary": each_data["summary"],
+                        "id": data["id"],
+                        "url": data["url"],
+                        "title": data["title"],
+                        "text": data["text"],
+                        "summary": data["summary"],
                     }
-                    yield each_data["id"], ex
+                    yield data["id"], ex
 
         elif self.config.schema == "seacrowd_t2t":
-            with jsonlines.open(filepath) as f:
-                for each_data in f.iter():
+            # the title is unused for this schema
+            with open(filepath, encoding="utf-8") as f:
+                for row in f:
+                    data = json.loads(row)
                     ex = {
-                        "id": each_data["id"],
-                        "text_1": each_data["text"],
-                        "text_2": each_data["summary"],
-                        "text_1_name": each_data["title"],
+                        "id": data["id"],
+                        "text_1": data["text"],
+                        "text_2": data["summary"],
+                        "text_1_name": "text",
                         "text_2_name": "summary"
                     }
-                    yield each_data["id"], ex
+                    yield data["id"], ex
         else:
             raise ValueError(f"Invalid config: {self.config.name}")

--- a/seacrowd/sea_datasets/xl_sum/xl_sum.py
+++ b/seacrowd/sea_datasets/xl_sum/xl_sum.py
@@ -1,3 +1,9 @@
+"""
+This new update refers to the this HF dataloader script
+https://huggingface.co/datasets/csebuetnlp/xlsum/blob/main/xlsum.py
+while conforming to SEACrowd schema
+"""
+
 import os
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -5,9 +11,9 @@ from typing import Dict, List, Tuple
 import json
 import datasets
 
+from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
-from seacrowd.utils import schemas
 
 
 _CITATION = """\
@@ -96,7 +102,7 @@ def construct_configs_on_langs() -> List[SEACrowdConfig]:
 
 
 class XLSum(datasets.GeneratorBasedBuilder):
-    """XL-Sum is a large-scale multilingual summarization dataset that covers 45 languages including Indonesian text summarization. The dataset is based on article-summary pairs from BBC, is highly abstractive, concise, and of high quality, as indicated by human and intrinsic evaluation."""
+    """XL-Sum is a large-scale multilingual summarization dataset that covers 45 languages including Indonesian text summarization."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)


### PR DESCRIPTION
Please name your PR title and the first line of PR message after the issue it will close. You can use the following examples:

Closes #32 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
