### PR TITLE
Video schema key change: `texts` to `text`

### DIFF
--- a/seacrowd/sea_datasets/fsl_105/fsl_105.py
+++ b/seacrowd/sea_datasets/fsl_105/fsl_105.py
@@ -95,7 +95,7 @@ class FSL105Dataset(datasets.GeneratorBasedBuilder):
                 {
                     "id": datasets.Value("string"),
                     "video_path": datasets.Value("string"),
-                    "texts": datasets.Value("string"),
+                    "text": datasets.Value("string"),
                     "labels": datasets.ClassLabel(names=self.category),
                     "metadata": {
                         "resolution": {
@@ -164,7 +164,7 @@ class FSL105Dataset(datasets.GeneratorBasedBuilder):
                 yield key, {
                     "id": str(key),
                     "video_path": os.path.join(filepath["clips"], example["vid_path"]),
-                    "texts": example["label"],
+                    "text": example["label"],
                     "labels": example["category"],
                     "metadata": {
                         "resolution": {
@@ -179,7 +179,7 @@ class FSL105Dataset(datasets.GeneratorBasedBuilder):
                 yield key, {
                     "id": str(key),
                     "video_path": os.path.join(filepath["clips"], example["vid_path"]),
-                    "texts": example["label"],
+                    "text": example["label"],
                     "metadata": {
                         "resolution": {
                             "width": vid_width,

--- a/seacrowd/sea_datasets/id_msvd/id_msvd.py
+++ b/seacrowd/sea_datasets/id_msvd/id_msvd.py
@@ -122,7 +122,7 @@ class IdMsvdDataset(datasets.GeneratorBasedBuilder):
                 yield i, {
                     "id": str(i),
                     "video_path": str(row["video_path"]),
-                    "texts": row["text"],
+                    "text": row["text"],
                     "metadata": {
                         "resolution": {
                             "width": None,

--- a/seacrowd/utils/schemas/video.py
+++ b/seacrowd/utils/schemas/video.py
@@ -14,7 +14,7 @@ features = datasets.Features(
     {
         "id": datasets.Value("string"),
         "video_path": datasets.Value("string"),
-        "texts": datasets.Value("string"),
+        "text": datasets.Value("string"),
         "metadata": {
             "resolution": {
                 "width": datasets.Value("int64"),


### PR DESCRIPTION
As discussed [here](https://github.com/SEACrowd/seacrowd-datahub/pull/135#discussion_r1490931571), for clarity purposes, I suggest changing the `texts` key to `text` so it will indicate a literal text (not a list of texts). Thus, I also changed the keys in relevant dataloaders (#135 & #185). Both dataloaders are already tested and all are OK.