### PR TITLE
Closes #102 | Add Dataloader for Thai SER

### DIFF
--- a/seacrowd/sea_datasets/thai_ser/thai_ser.py
+++ b/seacrowd/sea_datasets/thai_ser/thai_ser.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+# no paper citation
+_CITATION = """\
+"""
+_DATASETNAME = "thai_ser"
+_DESCRIPTION = """\
+THAI SER dataset consists of 5 main emotions assigned to actors: Neutral,
+Anger, Happiness, Sadness, and Frustration. The recordings were 41 hours,
+36 minutes long (27,854 utterances), and were performed by 200 professional
+actors (112 female, 88 male) and directed by students, former alumni, and
+professors from the Faculty of Arts, Chulalongkorn University. The THAI SER
+contains 100 recordings and is separated into two main categories: Studio and
+Zoom. Studio recordings also consist of two studio environments: Studio A, a
+controlled studio room with soundproof walls, and Studio B, a normal room
+without soundproof or noise control.
+"""
+_HOMEPAGE = "https://github.com/vistec-AI/dataset-releases/releases/tag/v1"
+_LANGUAGES = ["tha"]
+_LICENSE = Licenses.CC_BY_SA_4_0.value
+_LOCAL = False
+
+_URLS = {
+    "actor_demography": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/actor_demography.json",
+    "emotion_label": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/emotion_label.json",
+    "studio": {
+        "studio1-10": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio1-10.zip",
+        "studio11-20": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio11-20.zip",
+        "studio21-30": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio21-30.zip",
+        "studio31-40": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio31-40.zip",
+        "studio41-50": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio41-50.zip",
+        "studio51-60": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio51-60.zip",
+        "studio61-70": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio61-70.zip",
+        "studio71-80": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/studio71-80.zip",
+    },
+    "zoom": {"zoom1-10": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/zoom1-10.zip", "zoom11-20": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/zoom11-20.zip"},
+}
+
+_SUPPORTED_TASKS = [Tasks.SPEECH_EMOTION_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class ThaiSER(datasets.GeneratorBasedBuilder):
+    """Thai speech emotion recognition dataset THAI SER contains 100 recordings (80 studios and 20 zooms)."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    SEACROWD_SCHEMA_NAME = "speech"
+    _LABELS = ["Neutral", "Angry", "Happy", "Sad", "Frustrated"]
+
+    BUILDER_CONFIGS = [
+        # zoom
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}_zoom",
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=f"{_DATASETNAME}_zoom",
+        ),
+        # studio
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_studio_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}_studio",
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_studio_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
+            subset_id=f"{_DATASETNAME}_studio",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source" or self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            # same as schemas.speech_features(self._LABELS) except for sampling_rate
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "path": datasets.Value("string"),
+                    "audio": datasets.Audio(sampling_rate=44_100),
+                    "speaker_id": datasets.Value("string"),
+                    "labels": datasets.ClassLabel(names=self._LABELS),
+                    "metadata": {
+                        "speaker_age": datasets.Value("int64"),
+                        "speaker_gender": datasets.Value("string"),
+                    },
+                }
+            )
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        setting = "studio" if "studio" in self.config.name else "zoom"
+
+        data_paths = {"actor_demography": Path(dl_manager.download_and_extract(_URLS["actor_demography"])), "emotion_label": Path(dl_manager.download_and_extract(_URLS["emotion_label"])), setting: {}}
+        for url_name, url_path in _URLS[setting].items():
+            data_paths[setting][url_name] = Path(dl_manager.download_and_extract(url_path))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "actor_demography_filepath": data_paths["actor_demography"],
+                    "emotion_label_filepath": data_paths["emotion_label"],
+                    "data_filepath": data_paths[setting],
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, actor_demography_filepath: Path, emotion_label_filepath: Path, data_filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        # read actor_demography file
+        with open(actor_demography_filepath, "r", encoding="utf-8") as actor_demography_file:
+            actor_demography = json.load(actor_demography_file)
+        actor_demography_dict = {actor["Actor's ID"]: {"speaker_age": actor["Age"], "speaker_gender": actor["Sex"].lower()} for actor in actor_demography["data"]}
+
+        # read emotion_label file
+        with open(emotion_label_filepath, "r", encoding="utf-8") as emotion_label_file:
+            emotion_label = json.load(emotion_label_file)
+
+        # iterate through data folders
+        for folder_name, folder_path in data_filepath.items():
+            flac_files = glob.glob(os.path.join(folder_path, "**/*.flac"), recursive=True)
+            # iterate through recordings
+            for audio_path in flac_files:
+                id = audio_path.split("/")[-1]
+                speaker_id = id.split("_")[2].strip("actor")
+                # labels in emotion_label are incomplete, labels only provided for microphone types: mic, con
+                # otherwise, obtain label from id for scripted utterances and skip sample for the improvised utterances
+                if id in emotion_label.keys():
+                    assigned_emo = emotion_label[id][0]["assigned_emo"]
+                else:
+                    if "script" in id:
+                        label = id.split("_")[-1][0]  # Emotion (1 = Neutral, 2 = Angry, 3 = Happy, 4 = Sad, 5 = Frustrated)
+                        assigned_emo = self._LABELS[int(label) - 1]
+                    else:
+                        continue
+
+                if self.config.schema == "source" or self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+                    example = {
+                        "id": id.strip(".flac"),
+                        "path": audio_path,
+                        "audio": audio_path,
+                        "speaker_id": speaker_id,
+                        "labels": assigned_emo,
+                        "metadata": {"speaker_age": actor_demography_dict[speaker_id]["speaker_age"], "speaker_gender": actor_demography_dict[speaker_id]["speaker_gender"]},
+                    }
+
+                yield id.strip(".flac"), example

--- a/seacrowd/sea_datasets/thai_ser/thai_ser.py
+++ b/seacrowd/sea_datasets/thai_ser/thai_ser.py
@@ -120,7 +120,7 @@ class ThaiSER(datasets.GeneratorBasedBuilder):
                     "audio": datasets.Audio(sampling_rate=44_100),
                     "speaker_id": datasets.Value("string"),
                     "labels": datasets.ClassLabel(names=self._LABELS),
-                    "majority_emo": datasets.Value("string"),  # 'None' when no majority
+                    "majority_emo": datasets.Value("string"),  # 'None' when no single majority
                     "annotated": datasets.Value("string"),
                     "agreement": datasets.Value("float32"),
                     "metadata": {
@@ -203,6 +203,7 @@ class ThaiSER(datasets.GeneratorBasedBuilder):
                     if "script" in id:
                         label = id.split("_")[-1][0]  # Emotion (1 = Neutral, 2 = Angry, 3 = Happy, 4 = Sad, 5 = Frustrated)
                         assigned_emo = self._LABELS[int(label) - 1]
+                        majority_emo = agreement = annotated = None
                     else:
                         continue
 

--- a/seacrowd/sea_datasets/thai_ser/thai_ser.py
+++ b/seacrowd/sea_datasets/thai_ser/thai_ser.py
@@ -59,6 +59,7 @@ _URLS = {
     },
     "zoom": {"zoom1-10": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/zoom1-10.zip", "zoom11-20": "https://github.com/vistec-AI/dataset-releases/releases/download/v1/zoom11-20.zip"},
 }
+_URLS["studio_zoom"] = {**_URLS["studio"], **_URLS["zoom"]}
 
 _SUPPORTED_TASKS = [Tasks.SPEECH_EMOTION_RECOGNITION]
 
@@ -76,35 +77,35 @@ class ThaiSER(datasets.GeneratorBasedBuilder):
     _LABELS = ["Neutral", "Angry", "Happy", "Sad", "Frustrated"]
 
     BUILDER_CONFIGS = [
-        # zoom
+        # studio
         SEACrowdConfig(
             name=f"{_DATASETNAME}_source",
             version=SOURCE_VERSION,
             description=f"{_DATASETNAME} source schema",
             schema="source",
-            subset_id=f"{_DATASETNAME}_zoom",
+            subset_id=f"{_DATASETNAME}",
         ),
         SEACrowdConfig(
             name=f"{_DATASETNAME}_seacrowd_{SEACROWD_SCHEMA_NAME}",
             version=SEACROWD_VERSION,
             description=f"{_DATASETNAME} SEACrowd schema",
             schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
-            subset_id=f"{_DATASETNAME}_zoom",
+            subset_id=f"{_DATASETNAME}",
         ),
-        # studio
+        # studio and zoom
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_studio_source",
+            name=f"{_DATASETNAME}_include_zoom_source",
             version=SOURCE_VERSION,
             description=f"{_DATASETNAME} source schema",
             schema="source",
-            subset_id=f"{_DATASETNAME}_studio",
+            subset_id=f"{_DATASETNAME}_include_zoom",
         ),
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_studio_seacrowd_{SEACROWD_SCHEMA_NAME}",
+            name=f"{_DATASETNAME}_include_zoom_seacrowd_{SEACROWD_SCHEMA_NAME}",
             version=SEACROWD_VERSION,
             description=f"{_DATASETNAME} SEACrowd schema",
             schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}",
-            subset_id=f"{_DATASETNAME}_studio",
+            subset_id=f"{_DATASETNAME}_include_zoom",
         ),
     ]
 
@@ -156,7 +157,7 @@ class ThaiSER(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        setting = "studio" if "studio" in self.config.name else "zoom"
+        setting = "studio_zoom" if "zoom" in self.config.name else "studio"
 
         data_paths = {"actor_demography": Path(dl_manager.download_and_extract(_URLS["actor_demography"])), "emotion_label": Path(dl_manager.download_and_extract(_URLS["emotion_label"])), setting: {}}
         for url_name, url_path in _URLS[setting].items():


### PR DESCRIPTION
Closes #102 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
