### PR TITLE
Closes #421 | Add/Update Dataloader malaysia_ai_government

### DIFF
--- a/seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py
+++ b/seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py
@@ -1,0 +1,180 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@article{,
+  author    = {N/A},
+  title     = {No Publication},
+  journal   = {N/A},
+  volume    = {N/A},
+  year      = {N/A},
+  url       = {N/A},
+  doi       = {N/A},
+  biburl    = {N/A},
+  bibsource = {N/A}
+}
+"""
+
+_DATASETNAME = "malaysia_ai_government"
+
+_DESCRIPTION = """\
+This is a dataset containing pdfs scraped from 735 gov.my websites.
+It consists of thousands of the unedited text, a link to the URL where the website was retrieved, and the name of the pdf.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/malaysia-ai/crawl-my-website"
+
+_LANGUAGES = ["zlm"]
+
+
+_LICENSE = Licenses.APACHE_2_0.value
+
+_LOCAL = False
+
+
+_URLS = {
+    _DATASETNAME: "https://huggingface.co/datasets/malaysia-ai/crawl-my-website",
+}
+
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+_SUBSETS = ["gov_my", "govdocs", "muftiwp_gov_my", "myjms_mohe_gov_my"]
+
+
+class MalaysiaAIGovernmentDataset(datasets.GeneratorBasedBuilder):
+    """Thousands of the unedited text for Malay."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"malaysia_ai_government_{subset}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description=f"malaysia_ai_government_{subset} source schema",
+            schema="source",
+            subset_id=f"{subset}",
+        )
+        for subset in _SUBSETS
+    ] + [
+        SEACrowdConfig(
+            name=f"malaysia_ai_government_{subset}_seacrowd_ssp",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"malaysia_ai_government_{subset} SEACrowd schema",
+            schema="seacrowd_ssp",
+            subset_id=f"{subset}",
+        )
+        for subset in _SUBSETS
+    ]
+
+    DEFAULT_CONFIG_NAME = "malaysia_ai_government_gov_my_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "file": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "url": datasets.Value("string"),
+                }
+            )
+
+        # For example seacrowd_kb, seacrowd_t2t
+        elif self.config.schema == "seacrowd_ssp":
+            features = schemas.ssp_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        subset = self.config.subset_id
+        # data_dir = dl_manager.download_and_extract(urls)
+        # dl_manager not used since dataloader uses HF 'load_dataset'
+
+        # Not all datasets have predefined canonical train/val/test splits.
+        # If your dataset has no predefined splits, use datasets.Split.TRAIN for all of the data.
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": urls,
+                    "split": "train",
+                    "subset": subset,
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str, subset: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        subset_file = subset.replace("_", ".") + ".jsonl"
+
+        if "myjms_mohe_gov_my" in subset:
+            # the last subset has jsonl in the wrong format, actually it's a txt file
+            data = datasets.load_dataset("text", data_files=filepath + "/resolve/main/" + subset_file, split="train")
+        else:
+            data = datasets.load_dataset("/".join(filepath.split("/")[-2:]), split="train", data_files={"train": subset_file})
+
+        for key, sample in enumerate(data):
+            if self.config.schema == "source":
+                yield key, {
+                    "file": sample["file"] if "file" in sample else None,
+                    "text": sample["text"] if "text" in sample else sample["body"],
+                    "url": sample["url"] if "url" in sample else None,
+                }
+
+            elif self.config.schema == "seacrowd_ssp":
+                yield key, {
+                    "id": key,
+                    "text": sample["text"] if "text" in sample else sample["body"],
+                }
+
+
+
+# from datasets import load_dataset
+    
+# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_gov_my_seacrowd_ssp")
+# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_govdocs_seacrowd_ssp")
+# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_muftiwp_gov_my_seacrowd_ssp")
+# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_myjms_mohe_gov_my_seacrowd_ssp")
+
+# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_gov_my
+# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_govdocs
+# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_muftiwp_gov_my
+# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_myjms_mohe_gov_my
+

--- a/seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py
+++ b/seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+'''
+This is a dataset containing pdfs scraped from 735 gov.my websites.
+'''
 
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -24,16 +27,11 @@ from seacrowd.utils.configs import SEACrowdConfig
 from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
-@article{,
-  author    = {N/A},
-  title     = {No Publication},
-  journal   = {N/A},
-  volume    = {N/A},
-  year      = {N/A},
-  url       = {N/A},
-  doi       = {N/A},
-  biburl    = {N/A},
-  bibsource = {N/A}
+@article{malaysua_ai_government,
+  author    = {{Malaysia-AI}},
+  title     = {Crawl Malaysian Government},
+  year      = {2023},  % Change to the relevant year if known
+  url       = {https://huggingface.co/datasets/malaysia-ai/crawl-my-website
 }
 """
 
@@ -47,7 +45,6 @@ It consists of thousands of the unedited text, a link to the URL where the websi
 _HOMEPAGE = "https://huggingface.co/datasets/malaysia-ai/crawl-my-website"
 
 _LANGUAGES = ["zlm"]
-
 
 _LICENSE = Licenses.APACHE_2_0.value
 
@@ -163,18 +160,3 @@ class MalaysiaAIGovernmentDataset(datasets.GeneratorBasedBuilder):
                     "id": key,
                     "text": sample["text"] if "text" in sample else sample["body"],
                 }
-
-
-
-# from datasets import load_dataset
-    
-# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_gov_my_seacrowd_ssp")
-# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_govdocs_seacrowd_ssp")
-# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_muftiwp_gov_my_seacrowd_ssp")
-# data = load_dataset("seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py", name="malaysia_ai_government_myjms_mohe_gov_my_seacrowd_ssp")
-
-# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_gov_my
-# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_govdocs
-# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_muftiwp_gov_my
-# python -m tests.test_seacrowd seacrowd/sea_datasets/malaysia_ai_government/malaysia_ai_government.py --subset_id malaysia_ai_government_myjms_mohe_gov_my
-


### PR DESCRIPTION
**Title**: Closes #421 | Add/Update Dataloader malaysia_ai_government

**First line PR Message**: Closes #421

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [-] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
