### PR TITLE
Closes #437 | Create lex_indo dataset loader

### DIFF
--- a/seacrowd/sea_datasets/lex_indo/lex_indo.py
+++ b/seacrowd/sea_datasets/lex_indo/lex_indo.py
@@ -89,7 +89,7 @@ class LexIndo(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath: Path, split: str):
         """Yields examples as (key, example) tuples."""
 
-        with open("Indonesian_dic.txt", "r") as f:
+        with open(f"{filepath}/Indonesian_dic.txt", "r") as f:
             data = f.readlines()
 
         if self.config.schema == "source":

--- a/seacrowd/sea_datasets/lex_indo/lex_indo.py
+++ b/seacrowd/sea_datasets/lex_indo/lex_indo.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses
+
+_CITATION = """\
+@misc{magichubLEXIndoIndonesian,
+  author    = {},
+  title     = {LEX-INDO: AN INDONESIAN LEXICON},
+  year      = {},
+  howpublished = {Online},
+  url       = {https://magichub.com/datasets/indonesian-lexicon/},
+  note      = {Accessed 19-03-2024},
+}
+"""
+
+_DATASETNAME = "lex_indo"
+
+_DESCRIPTION = """This open-source lexicon consists of 2,000 common Indonesian words, with phoneme series attached.
+It is intended to be used as the lexicon for an automatic speech recognition system or a text-to-speech system.
+The dictionary presents words as well as their pronunciation transcribed with an ARPABET(phone set of CMU)-like phone set. Syllables are separated with dots.
+"""
+
+_HOMEPAGE = "https://magichub.com/datasets/indonesian-lexicon/"
+_LICENSE = Licenses.CC_BY_NC_ND_4_0.value
+_LOCAL = True
+
+_URLS = {}
+
+_SUPPORTED_TASKS = []
+
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class LexIndo(datasets.GeneratorBasedBuilder):
+    """This open-source lexicon consists of 2,000 common Indonesian words, with phoneme series attached"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description="lex_indo lexicon with source schema",
+            schema="source",
+            subset_id="lex_indo",
+        )
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        schema = self.config.schema
+        if schema == "source":
+            features = datasets.Features({"id": datasets.Value("string"), "word": datasets.Value("string"), "phoneme": datasets.Value("string")})
+        else:
+            raise NotImplementedError()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None:
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str):
+        """Yields examples as (key, example) tuples."""
+
+        with open("Indonesian_dic.txt", "r") as f:
+            data = f.readlines()
+
+        if self.config.schema == "source":
+            for idx, text in enumerate(data):
+                row = {"id": str(idx), "word": text.split()[0], "phoneme": " ".join(text.split()[1:])}
+                yield idx, row
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")


### PR DESCRIPTION
Closes #437 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

![image](https://github.com/SEACrowd/seacrowd-datahub/assets/68073738/38ac4af8-11f4-40c1-9fed-d91bb3c1c8ce)

