### PR TITLE
Closes #424 | Add Dataloader Bactrian-X

### DIFF
--- a/seacrowd/sea_datasets/bactrian_x/bactrian_x.py
+++ b/seacrowd/sea_datasets/bactrian_x/bactrian_x.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses, TASK_TO_SCHEMA, SCHEMA_TO_FEATURES
+
+_CITATION = """\
+@misc{li2023bactrianx,
+      title={Bactrian-X : A Multilingual Replicable Instruction-Following Model with Low-Rank Adaptation}, 
+      author={Haonan Li and Fajri Koto and Minghao Wu and Alham Fikri Aji and Timothy Baldwin},
+      year={2023},
+      eprint={2305.15011},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
+
+_DATASETNAME = "bactrian_x"
+
+_DESCRIPTION = """\
+The Bactrain-X dataset is a collection of 3.4M instruction-response pairs in 52
+languages, that are obtained by translating 67K English instructions (alpaca-52k
++ dolly-15k) into 51 languages using Google Translate API. The translated
+instructions are then fed to ChatGPT (gpt-3.5-turbo) to obtain its natural
+responses, resulting in 3.4M instruction-response pairs in 52 languages (52
+languages x 67k instances = 3.4M instances). Human evaluations were conducted to
+evaluate response quality for several languages, with those of interest to
+SEACrowd being Burmese and Tagalog.
+"""
+
+_HOMEPAGE = "https://github.com/mbzuai-nlp/Bactrian-X"
+
+_LANGUAGES = ["mya", "tgl", "ind", "khm", "tha", "vie"]
+
+_LICENSE = Licenses.CC_BY_NC_4_0.value
+
+_LOCAL = False
+
+_BASE_URL = "https://huggingface.co/datasets/MBZUAI/Bactrian-X/resolve/main/data/{subset}.json.gz?download=true"
+_SUBSETS = ["my", "tl", "id", "km", "th", "vi"]
+
+_SUPPORTED_TASKS = [Tasks.INSTRUCTION_TUNING]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # t2t
+
+_SOURCE_VERSION = "1.0.1"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class BactrianXDataset(datasets.GeneratorBasedBuilder):
+    """A collection of translated instruction-response pairs, evaluated with ChatGPT and human."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset in _SUBSETS:
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {subset} source schema",
+                schema="source",
+                subset_id=subset,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {subset} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=subset,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_id_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "instruction": datasets.Value("string"),
+                    "input": datasets.Value("string"),
+                    "id": datasets.Value("string"),
+                    "output": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        data_url = _BASE_URL.format(subset=self.config.name.split("_")[2])
+        data_path = Path(dl_manager.download_and_extract(data_url))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_path": data_path,
+                },
+            )
+        ]
+
+    def _generate_examples(self, data_path: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(data_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        if self.config.schema == "source":
+            for idx, example in enumerate(data):
+                yield idx, {
+                    "instruction": example["instruction"],
+                    "input": example["input"],
+                    "id": example["id"],
+                    "output": example["output"],
+                }
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            for idx, example in enumerate(data):
+                yield idx, {
+                    "id": example["id"],
+                    "text_1": f"Instruction: {example['instruction']}\nInput: {example['input']}",
+                    "text_2": example["output"],
+                    "text_1_name": "instruction + input",
+                    "text_2_name": "output",
+                }


### PR DESCRIPTION
Closes #424

I implemented one config per language/subset. Thus, configs will look like this: `bactrian_x_id_source`, `bactrian_x_km_seacrowd_t2t`, etc. When testing, pass `bactrian_x_<subset>` to the `--subset_id` parameter.

As there is one more variable for the input response in the source schema, I added that manually as `Instruction: {instruction}\nInput: {input}"` in `text_1` of `seacrowd_t2t` schema. I don't know if that is allowed, so let's discuss.

Note that for Khmer subset, the loaded data will look as follows:
```
INFO:__main__:Dataset sample [source]
{'instruction': 'តើ\u200bស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bអ្វីខ្លះ?', 'input': '', 'id': 'dolly-10828', 'output': 'ស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bវាប្រកាស\u200bពី\u200bប្រភេទ\u200bនិង\u200bលក្ខណៈ\u200bរបស់\u200bរូបភាព\u200b។ វាតម្រូវ\u200bឲ្យ\u200bទៅ\u200bដល់\u200bលក្ខណៈ\u200bប្រូបាបនៃ\u200bរូបភាព\u200bដែល\u200bប្រើ\u200bដើម្បី\u200bថត\u200bបន្ទាត់\u200bស្មើ\u200bនឹង\u200bតម្លៃ\u200bមួយ\u200bចំនួន\u200b។ ក្នុង\u200bបំណង\u200bនេះ\u200bនៃ\u200bការថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bករណី\u200bដូចជា\u200bប្រូបាប\u200bពណ៌\u200bរូបភាព\u200bក្បែរ\u200bតែ\u200bមិន\u200bត្រូវ\u200bបាន\u200bប្រាកដ\u200bនៅពេលដែល\u200bវា\u200bល្អបំផុត\u200bទេ\u200b។ គុណភាព\u200bរូបភាព\u200bមាន\u200bតម្លៃ\u200bបំផុត\u200bនៅ\u200bពេល\u200bដែល\u200bវា\u200bអាច\u200bប្រើ\u200bបាន\u200bទៅ\u200bនឹង\u200bប្រិតប្រយ័ត្ន\u200bនៃ\u200bវាល\u200bផ្សេងទៀត\u200bដែល\u200bវា\u200bត្រូវ\u200bបានផ្ដល់។'}
INFO:__main__:Dataset sample [seacrowd_t2t]
{'id': 'dolly-10828', 'text_1': 'Instruction: តើ\u200bស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bអ្វីខ្លះ?\nInput: ', 'text_2': 'ស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bវាប្រកាស\u200bពី\u200bប្រភេទ\u200bនិង\u200bលក្ខណៈ\u200bរបស់\u200bរូបភាព\u200b។ វាតម្រូវ\u200bឲ្យ\u200bទៅ\u200bដល់\u200bលក្ខណៈ\u200bប្រូបាបនៃ\u200bរូបភាព\u200bដែល\u200bប្រើ\u200bដើម្បី\u200bថត\u200bបន្ទាត់\u200bស្មើ\u200bនឹង\u200bតម្លៃ\u200bមួយ\u200bចំនួន\u200b។ ក្នុង\u200bបំណង\u200bនេះ\u200bនៃ\u200bការថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bករណី\u200bដូចជា\u200bប្រូបាប\u200bពណ៌\u200bរូបភាព\u200bក្បែរ\u200bតែ\u200bមិន\u200bត្រូវ\u200bបាន\u200bប្រាកដ\u200bនៅពេលដែល\u200bវា\u200bល្អបំផុត\u200bទេ\u200b។ គុណភាព\u200bរូបភាព\u200bមាន\u200bតម្លៃ\u200bបំផុត\u200bនៅ\u200bពេល\u200bដែល\u200bវា\u200bអាច\u200bប្រើ\u200bបាន\u200bទៅ\u200bនឹង\u200bប្រិតប្រយ័ត្ន\u200bនៃ\u200bវាល\u200bផ្សេងទៀត\u200bដែល\u200bវា\u200bត្រូវ\u200bបានផ្ដល់។', 'text_1_name': 'instruction + input', 'text_2_name': 'output'}
```
At first, I thought this should be an encoding problem and need to be solved. But turns out I also get the same result when loading from HF directly as follows:
```python
from datasets import load_dataset

data = load_dataset("MBZUAI/Bactrian-X", "km")
print(data['train'][0])
# {'instruction': 'តើ\u200bស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bអ្វីខ្លះ?', 'input': '', 'id': 'dolly-10828', 'output': 'ស៊ុម\u200bក្រិត\u200bក្នុង\u200bការ\u200bថត\u200bរូប\u200bតារាសាស្ត្រ\u200bវាប្រកាស\u200bពី\u200bប្រភេទ\u200bនិង\u200bលក្ខណៈ\u200bរបស់\u200bរូបភាព\u200b។ វាតម្រូវ\u200bឲ្យ\u200bទៅ\u200bដល់\u200bលក្ខណៈ\u200bប្រូបាបនៃ\u200bរូបភាព\u200bដែល\u200bប្រើ\u200bដើម្បី\u200bថត\u200bបន្ទាត់\u200bស្មើ\u200bនឹង\u200bតម្លៃ\u200bមួយ\u200bចំនួន\u200b។ ក្នុង\u200bបំណង\u200bនេះ\u200bនៃ\u200bការថត\u200bរូប\u200bតារាសាស្ត្រ\u200bមាន\u200bករណី\u200bដូចជា\u200bប្រូបាប\u200bពណ៌\u200bរូបភាព\u200bក្បែរ\u200bតែ\u200bមិន\u200bត្រូវ\u200bបាន\u200bប្រាកដ\u200bនៅពេលដែល\u200bវា\u200bល្អបំផុត\u200bទេ\u200b។ គុណភាព\u200bរូបភាព\u200bមាន\u200bតម្លៃ\u200bបំផុត\u200bនៅ\u200bពេល\u200bដែល\u200bវា\u200bអាច\u200bប្រើ\u200bបាន\u200bទៅ\u200bនឹង\u200bប្រិតប្រយ័ត្ន\u200bនៃ\u200bវាល\u200bផ្សេងទៀត\u200bដែល\u200bវា\u200bត្រូវ\u200bបានផ្ដល់។'}
```

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
