### PR TITLE
Closes #535 | Add Dataloader CulturaY

### DIFF
--- a/seacrowd/sea_datasets/culturay/culturay.py
+++ b/seacrowd/sea_datasets/culturay/culturay.py
@@ -43,9 +43,11 @@ dataset of 15TB (uncompressed)/3TB (zstd-compressed) that applies the same
 dataset cleaning methodology to the HPLT v1.1 dataset. Please note that HPLT
 v1.2 has also been released and is an alternative verison with different
 cleaning methodolgies. This data was used in part to train our SOTA Vietnamese
-model: Vistral-7B-Chat. Before using this dataloader, please accept the
-acknowledgement at https://huggingface.co/datasets/ontocord/CulturaY and use
-huggingface-cli login for authentication.
+model: Vistral-7B-Chat.
+
+Before using this dataloader, please accept the acknowledgement at
+https://huggingface.co/datasets/ontocord/CulturaY and use huggingface-cli login
+for authentication.
 """
 
 _HOMEPAGE = "https://huggingface.co/datasets/ontocord/CulturaY"
@@ -125,7 +127,9 @@ class CulturaYDataset(datasets.GeneratorBasedBuilder):
         subset = self.config.subset_id
         base_path = _BASE_URL.format(lang=subset)
 
-        file_list = HfFileSystem().ls(f"datasets/ontocord/CulturaY/{subset}", detail=False)
+        fs = HfFileSystem(token=dl_manager.download_config.token)
+        file_list = fs.ls(f"datasets/ontocord/CulturaY/{subset}", detail=False)
+
         data_urls = [
             f"{base_path}{filename.split('/')[-1]}"
             for filename in file_list

--- a/seacrowd/sea_datasets/culturay/culturay.py
+++ b/seacrowd/sea_datasets/culturay/culturay.py
@@ -59,7 +59,6 @@ _LICENSE = Licenses.CC_BY_4_0.value
 _LOCAL = False
 
 _BASE_URL = "https://huggingface.co/datasets/ontocord/CulturaY/resolve/main/{lang}/"
-_SUBSETS = ["my", "tl", "ms", "vi", "id", "th"]
 
 _SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
 _SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # ssp
@@ -76,7 +75,7 @@ class CulturaYDataset(datasets.GeneratorBasedBuilder):
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
     BUILDER_CONFIGS = []
-    for subset in _SUBSETS:
+    for subset in _LANGUAGES:
         BUILDER_CONFIGS += [
             SEACrowdConfig(
                 name=f"{_DATASETNAME}_{subset}_source",
@@ -124,7 +123,8 @@ class CulturaYDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators. Data is not yet extracted for efficient generation."""
-        subset = self.config.subset_id
+        lang_dict = {"mya": "my", "fil": "tl", "zlm": "ms", "vie": "vi", "ind": "id", "tha": "th"}
+        subset = lang_dict[self.config.subset_id]
         base_path = _BASE_URL.format(lang=subset)
 
         fs = HfFileSystem(token=dl_manager.download_config.token)

--- a/seacrowd/sea_datasets/culturay/culturay.py
+++ b/seacrowd/sea_datasets/culturay/culturay.py
@@ -1,0 +1,173 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import zstandard as zstd
+from huggingface_hub import HfFileSystem
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import (SCHEMA_TO_FEATURES, TASK_TO_SCHEMA,
+                                      Licenses, Tasks)
+
+_CITATION = """\
+@misc{nguyen2024culturay,
+      title={CulturaY: A Large Cleaned Multilingual Dataset of 75 Languages}, 
+      author={Thuat Nguyen, Huu Nguyen and Thien Nguyen},
+      year={2024},
+}
+"""
+
+_DATASETNAME = "culturay"
+
+_DESCRIPTION = """\
+CulturaY: A Large Cleaned Multilingual Dataset of 75 Languages From the team
+that brought you CulutraX, we present CulturaY, another substantial multilingual
+dataset of 15TB (uncompressed)/3TB (zstd-compressed) that applies the same
+dataset cleaning methodology to the HPLT v1.1 dataset. Please note that HPLT
+v1.2 has also been released and is an alternative verison with different
+cleaning methodolgies. This data was used in part to train our SOTA Vietnamese
+model: Vistral-7B-Chat. Before using this dataloader, please accept the
+acknowledgement at https://huggingface.co/datasets/ontocord/CulturaY and use
+huggingface-cli login for authentication.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/ontocord/CulturaY"
+
+_LANGUAGES = ["mya", "fil", "zlm", "vie", "ind", "tha"]
+
+_LICENSE = Licenses.CC_BY_4_0.value
+
+_LOCAL = False
+
+_BASE_URL = "https://huggingface.co/datasets/ontocord/CulturaY/resolve/main/{lang}/"
+_SUBSETS = ["my", "tl", "ms", "vi", "id", "th"]
+
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # ssp
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class CulturaYDataset(datasets.GeneratorBasedBuilder):
+    """Substantial multilingual dataset by cleaning HPLT v1.1 (Internet Archive) data."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset in _SUBSETS:
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {subset} source schema",
+                schema="source",
+                subset_id=subset,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {subset} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=subset,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_my_source"  # smallest wrt n_doc
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("int64"),
+                    "document_lang": datasets.Value("string"),
+                    "scores": datasets.Sequence(datasets.Value("float64")),
+                    "langs": datasets.Sequence(datasets.Value("string")),
+                    "text": datasets.Value("string"),
+                    "url": datasets.Value("string"),
+                    "collection": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # ssp_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators. Data is not yet extracted for efficient generation."""
+        subset = self.config.subset_id
+        base_path = _BASE_URL.format(lang=subset)
+
+        file_list = HfFileSystem().ls(f"datasets/ontocord/CulturaY/{subset}", detail=False)
+        data_urls = [
+            f"{base_path}{filename.split('/')[-1]}"
+            for filename in file_list
+            if filename.endswith(".jsonl.zst")
+        ]
+
+        data_paths = list(map(Path, dl_manager.download(data_urls)))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_paths": data_paths,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_paths: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        key = 0
+        for data_path in data_paths:
+            with open(data_path, "rb") as f:
+                # Zstandard decompression
+                dctx = zstd.ZstdDecompressor()
+                reader = dctx.stream_reader(f)
+                text_io = io.TextIOWrapper(reader, encoding="utf-8")
+
+                # read jsonl file by line and yield
+                for line in text_io:
+                    data = json.loads(line)
+                    if self.config.schema == "source":
+                        yield key, {
+                            "id": data["id"],
+                            "document_lang": data["document_lang"],
+                            "scores": data["scores"],
+                            "langs": data["langs"],
+                            "text": data["text"],
+                            "url": data["url"],
+                            "collection": data["collection"],
+                        }
+                    elif self.config.schema == _SEACROWD_SCHEMA:
+                        yield key, {
+                            "id": str(data["id"]),
+                            "text": data["text"],
+                        }
+                    key += 1


### PR DESCRIPTION
Closes #535 

I implemented one config per language/subset. Thus, configs will look like this: `culturay_id_source`, `culturay_my_seacrowd_ssp`, etc. When testing, pass `culturay_<subset>` to the `--subset_id` parameter.

Due to the large dataset, it will take time to test.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.