### PR TITLE
Closes #522 | Add Dataloader Duolingo STAPLE 2020

### DIFF
--- a/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
+++ b/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
@@ -47,22 +47,6 @@ _CITATION = """\
     url = "https://aclanthology.org/2020.ngt-1.28",
     doi = "10.18653/v1/2020.ngt-1.28",
     pages = "232--243",
-    abstract = "We present the task of Simultaneous Translation and Paraphrasing
-    for Language Education (STAPLE). Given a prompt in one language, the goal is
-    to generate a diverse set of correct translations that language learners are
-    likely to produce. This is motivated by the need to create and maintain
-    large, high-quality sets of acceptable translations for exercises in a
-    language-learning application, and synthesizes work spanning machine
-    translation, MT evaluation, automatic paraphrasing, and language education
-    technology. We developed a novel corpus with unique properties for five
-    languages (Hungarian, Japanese, Korean, Portuguese, and Vietnamese), and
-    report on the results of a shared task challenge which attracted 20 teams to
-    solve the task. In our meta-analysis, we focus on three aspects of the
-    resulting systems: external training corpus selection, model architecture
-    and training decisions, and decoding and filtering strategies. We find that
-    strong systems start with a large amount of generic training data, and then
-    fine-tune with in-domain data, sampled according to our provided learner
-    response frequencies.",
 }
 """
 
@@ -85,7 +69,7 @@ _LICENSE = Licenses.CC_BY_NC_4_0.value
 
 _LOCAL = True  # needs to fill a form to download the dataset (dynamic link)
 
-_URLS = {}
+_URLS = "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/38OJR6&version=6.0"
 _SUBSETS = ["aws_baseline", "gold"]
 
 _SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]

--- a/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
+++ b/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
@@ -1,0 +1,259 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import SCHEMA_TO_FEATURES, TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = """\
+@inproceedings{mayhew-etal-2020-simultaneous,
+    title = "Simultaneous Translation and Paraphrase for Language Education",
+    author = "Mayhew, Stephen  and
+        Bicknell, Klinton  and
+        Brust, Chris  and
+        McDowell, Bill  and
+        Monroe, Will  and
+        Settles, Burr",
+    editor = "Birch, Alexandra  and
+        Finch, Andrew  and
+        Hayashi, Hiroaki  and
+        Heafield, Kenneth  and
+        Junczys-Dowmunt, Marcin  and
+        Konstas, Ioannis  and
+        Li, Xian  and
+        Neubig, Graham  and
+        Oda, Yusuke",
+    booktitle = "Proceedings of the Fourth Workshop on Neural Generation and Translation",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2020.ngt-1.28",
+    doi = "10.18653/v1/2020.ngt-1.28",
+    pages = "232--243",
+    abstract = "We present the task of Simultaneous Translation and Paraphrasing
+    for Language Education (STAPLE). Given a prompt in one language, the goal is
+    to generate a diverse set of correct translations that language learners are
+    likely to produce. This is motivated by the need to create and maintain
+    large, high-quality sets of acceptable translations for exercises in a
+    language-learning application, and synthesizes work spanning machine
+    translation, MT evaluation, automatic paraphrasing, and language education
+    technology. We developed a novel corpus with unique properties for five
+    languages (Hungarian, Japanese, Korean, Portuguese, and Vietnamese), and
+    report on the results of a shared task challenge which attracted 20 teams to
+    solve the task. In our meta-analysis, we focus on three aspects of the
+    resulting systems: external training corpus selection, model architecture
+    and training decisions, and decoding and filtering strategies. We find that
+    strong systems start with a large amount of generic training data, and then
+    fine-tune with in-domain data, sampled according to our provided learner
+    response frequencies.",
+}
+"""
+
+_DATASETNAME = "duolingo_staple_2020"
+
+_DESCRIPTION = """\
+This dataset is provided by Duolingo for their Simultaneous Translation and
+Paraphrase for Language Education (STAPLE) shared task in 2020. It contains
+English prompts and corresponding sets of plausible translations in five other
+languages, including Vietnamese. Each prompt is provided with a baseline
+automatic reference translation from Amazon, as well as some accepted
+translations with corresponding user response rates used for task scoring.
+"""
+
+_HOMEPAGE = "https://sharedtask.duolingo.com/#data"
+
+_LANGUAGES = ["vie"]
+
+_LICENSE = Licenses.CC_BY_NC_4_0.value
+
+_LOCAL = True  # needs to fill a form to download the dataset (dynamic link)
+
+_URLS = {}
+_SUBSETS = ["aws_baseline", "gold"]
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # t2t
+
+_SOURCE_VERSION = "6.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class DuolingoStaple2020Dataset(datasets.GeneratorBasedBuilder):
+    """Dataset for the Duolingo STAPLE 2020 shared task."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset in _SUBSETS:
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {subset} source schema",
+                schema="source",
+                subset_id=subset,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {subset} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=subset,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_gold_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            if self.config.subset_id == "aws_baseline":
+                features = datasets.Features(
+                    {
+                        "prompt_id": datasets.Value("string"),
+                        "source_text": datasets.Value("string"),
+                        "translation": datasets.Value("string"),
+                    }
+                )
+            elif self.config.subset_id == "gold":
+                features = datasets.Features(
+                    {
+                        "prompt_id": datasets.Value("string"),
+                        "source_text": datasets.Value("string"),
+                        "translations": [
+                            {
+                                "text": datasets.Value("string"),
+                                "weight": datasets.Value("float64"),
+                            }
+                        ],
+                    }
+                )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg (staple-2020 dir) to load_dataset."
+            )
+        else:
+            data_dir = Path(self.config.data_dir) / "en_vi"
+
+        if self.config.subset_id == "aws_baseline":
+            filename = "aws_baseline.pred"
+        elif self.config.subset_id == "gold":
+            filename = "2020-02-20.gold"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / f"train.en_vi.{'2020-01-13.gold' if self.config.subset_id == 'gold' else filename}.txt",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir / f"test.en_vi.{filename}.txt",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir / f"dev.en_vi.{filename}.txt",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # aws_baseline subset
+        if self.config.subset_id == "aws_baseline":
+            with open(filepath, "r", encoding="utf-8") as f:
+                entries = f.read().strip().split("\n\n")
+
+            for key, entry in enumerate(entries):
+                parts = entry.split("|")
+                prompt_id = parts[0].strip()
+                source_text, translation = list(map(str.strip, parts[1].split("\n")))
+
+                if self.config.schema == "source":
+                    yield key, {
+                        "prompt_id": prompt_id,
+                        "source_text": source_text,
+                        "translation": translation,
+                    }
+                elif self.config.schema == _SEACROWD_SCHEMA:
+                    yield key, {
+                        "id": str(key),
+                        "text_1": source_text,
+                        "text_2": translation,
+                        "text_1_name": "english",
+                        "text_2_name": "translation",
+                    }
+
+        # gold subset
+        elif self.config.subset_id == "gold":
+            with open(filepath, "r", encoding="utf-8") as f:
+                entries = f.read().strip().split("\n\n")
+
+            key = 0
+            for entry in entries:
+                parts = entry.split("\n")
+                prompt_id, source_text = list(map(str.strip, parts[0].split("|")))
+
+                if self.config.schema == "source":
+                    translations = []
+                    for answer in parts[1:]:
+                        translation, weight = list(map(str.strip, answer.split("|")))
+                        translations.append(
+                            {"text": translation, "weight": float(weight)}
+                        )
+                    yield key, {
+                        "prompt_id": prompt_id,
+                        "source_text": source_text,
+                        "translations": translations,
+                    }
+                    key += 1
+
+                elif self.config.schema == _SEACROWD_SCHEMA:
+                    for answer in parts[1:]:
+                        translation, _ = list(map(str.strip, answer.split("|")))
+                        yield key, {
+                            "id": str(key),
+                            "text_1": source_text,
+                            "text_2": translation,
+                            "text_1_name": "english",
+                            "text_2_name": "translation",
+                        }
+                        key += 1

--- a/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
+++ b/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
@@ -71,6 +71,9 @@ _LICENSE = Licenses.CC_BY_NC_4_0.value
 _LOCAL = True  # needs to fill a form to download the dataset (dynamic link)
 
 _URLS = "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/38OJR6&version=6.0"
+
+# `aws_baseline` refers to reference translations from Amazon Automated MT model,
+# while `gold` refers to translations accepted by Duolingo learners
 _SUBSETS = ["aws_baseline", "gold"]
 
 _SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]

--- a/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
+++ b/seacrowd/sea_datasets/duolingo_staple_2020/duolingo_staple_2020.py
@@ -19,7 +19,8 @@ from typing import Dict, List, Tuple
 import datasets
 
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import SCHEMA_TO_FEATURES, TASK_TO_SCHEMA, Licenses, Tasks
+from seacrowd.utils.constants import (SCHEMA_TO_FEATURES, TASK_TO_SCHEMA,
+                                      Licenses, Tasks)
 
 _CITATION = """\
 @inproceedings{mayhew-etal-2020-simultaneous,
@@ -131,9 +132,7 @@ class DuolingoStaple2020Dataset(datasets.GeneratorBasedBuilder):
                     }
                 )
         elif self.config.schema == _SEACROWD_SCHEMA:
-            features = SCHEMA_TO_FEATURES[
-                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
-            ]  # text2text_features
+            features = SCHEMA_TO_FEATURES[TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]]  # text2text_features
 
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
@@ -146,9 +145,7 @@ class DuolingoStaple2020Dataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         if self.config.data_dir is None:
-            raise ValueError(
-                "This is a local dataset. Please pass the data_dir kwarg (staple-2020 dir) to load_dataset."
-            )
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg (staple-2020 dir) to load_dataset.")
         else:
             data_dir = Path(self.config.data_dir) / "en_vi"
 
@@ -161,8 +158,7 @@ class DuolingoStaple2020Dataset(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": data_dir
-                    / f"train.en_vi.{'2020-01-13.gold' if self.config.subset_id == 'gold' else filename}.txt",
+                    "filepath": data_dir / f"train.en_vi.{'2020-01-13.gold' if self.config.subset_id == 'gold' else filename}.txt",
                 },
             ),
             datasets.SplitGenerator(
@@ -220,9 +216,7 @@ class DuolingoStaple2020Dataset(datasets.GeneratorBasedBuilder):
                     translations = []
                     for answer in parts[1:]:
                         translation, weight = list(map(str.strip, answer.split("|")))
-                        translations.append(
-                            {"text": translation, "weight": float(weight)}
-                        )
+                        translations.append({"text": translation, "weight": float(weight)})
                     yield key, {
                         "prompt_id": prompt_id,
                         "source_text": source_text,


### PR DESCRIPTION
Closes #522 

I implemented one config per language/subset. Thus, configs will look like this: `duolingo_staple_2020_aws_baseline_source`, `duolingo_staple_2020_gold_seacrowd_t2t`, etc. When testing, pass `duolingo_staple_2020_<subset>` to the `--subset_id` parameter.

Also, this one is a local dataset since you need to fill a form to download them [here](https://doi.org/10.7910/DVN/38OJR6) (no static URL provided). So don't forget to pass where you store `staple-2020` data to `data_dir` parameter.

Here are the test results:
[duolingo_staple_2020_aws_baseline.txt](https://github.com/SEACrowd/seacrowd-datahub/files/14815203/duolingo_staple_2020_aws_baseline.txt)
[duolingo_staple_2020_gold.txt](https://github.com/SEACrowd/seacrowd-datahub/files/14815202/duolingo_staple_2020_gold.txt)

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files

