### PR TITLE
Closes #312 | Create lio_and_central_flores dataset loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ openpyxl
 translate-toolkit==3.7.3
 typing_extensions
 scikit-learn==1.1.2
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,3 @@ openpyxl
 translate-toolkit==3.7.3
 typing_extensions
 scikit-learn==1.1.2
-beautifulsoup4

--- a/seacrowd/sea_datasets/lio_and_central_flores/lio_and_central_flores.py
+++ b/seacrowd/sea_datasets/lio_and_central_flores/lio_and_central_flores.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from typing import List, Tuple
+
+import datasets
+
+from seacrowd.sea_datasets.lio_and_central_flores import processing
+from seacrowd.sea_datasets.lio_and_central_flores.path_url import _URLS_DICT
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@misc{alexthesis2018,
+  author    = {Alexander Elias},
+  title     = {Lio and the Central Flores languages},
+  year      = {2018},
+  month     = {November},
+  address   = {Rapenburg 70, 2311 EZ Leiden},
+  school    = {Universiteit Leiden},
+  url       = {https://studenttheses.universiteitleiden.nl/handle/1887/69452},
+  note      = {Research Master's thesis},
+}
+"""
+
+_DATASETNAME = "lio_and_central_flores"
+_DESCRIPTION = """This dataset is a collection of language resources of Li'o, Ende, Nage, and
+So'a which are collected in Ende, Flores, Eastern Nusa Tenggara. This dataset
+is the dataset from the research MA thesis by Alexander Elias. Title: Lio and the Central Flores languages
+"""
+_HOMEPAGE = "https://archive.mpi.nl/tla/islandora/search/alexander%20elias?type=dismax&islandora_solr_search_navigation=0&f%5B0%5D=cmd.Contributor%3A%22Alexander%5C%20Elias%22"
+_LICENSE = Licenses.UNKNOWN.value
+_LANGUAGES = ["end", "nxe", "ljl"]
+LANGUAGES_TO_FILENAME_MAP = {
+    "end": "ENDE",
+    "nxe": "NAGE",
+    "ljl": "LIO",
+}
+_LOCAL = False
+
+_URLS = _URLS_DICT
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+
+class LioAndCentralFlores(datasets.GeneratorBasedBuilder):
+    """This dataset is a collection of language resources of Li'o, Ende, Nage, and So'a"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    SEACROWD_SCHEMA_NAME = "t2t"
+
+    dataset_names = sorted([f"{_DATASETNAME}_{lang}" for lang in _LANGUAGES])
+    BUILDER_CONFIGS = []
+    for name in dataset_names:
+        if name.split("_")[4] == "nxe":
+            source_config = SEACrowdConfig(name=f"{name}_wordlist_source", version=SOURCE_VERSION, description=f"{_DATASETNAME} source schema", schema="source", subset_id=name)
+            BUILDER_CONFIGS.append(source_config)
+            source_config = SEACrowdConfig(name=f"{_DATASETNAME}_nxe_eng_wordlist_source", version=SOURCE_VERSION, description=f"{_DATASETNAME} source schema", schema="source", subset_id=name)
+            BUILDER_CONFIGS.append(source_config)
+        else:
+            source_config = SEACrowdConfig(name=f"{name}_source", version=SOURCE_VERSION, description=f"{_DATASETNAME} source schema", schema="source", subset_id=name)
+            BUILDER_CONFIGS.append(source_config)
+            seacrowd_config = SEACrowdConfig(name=f"{name}_seacrowd_{SEACROWD_SCHEMA_NAME}", version=SEACROWD_VERSION, description=f"{_DATASETNAME} SEACrowd schema", schema=f"seacrowd_{SEACROWD_SCHEMA_NAME}", subset_id=name)
+            BUILDER_CONFIGS.append(seacrowd_config)
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            if self.config.name.split("_")[4] == "nxe":
+                features = datasets.Features({"id": datasets.Value("string"), "word": datasets.Value("string")})
+            else:
+                features = datasets.Features({"source_sentence": datasets.Value("string"), "target_sentence": datasets.Value("string"), "source_lang": datasets.Value("string"), "target_lang": datasets.Value("string")})
+        elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+            features = schemas.text2text_features
+        else:
+            raise ValueError("Invalid config schema")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        lang = self.config.name.split("_")[4]
+        if lang in _LANGUAGES:
+            filepath = {k: v["text_path"] for k, v in _URLS[LANGUAGES_TO_FILENAME_MAP[lang]].items()}
+            paths = dl_manager.download(filepath)
+        else:
+            raise ValueError("Invalid language name")
+
+        return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"filepath": paths, "language": lang})]
+
+    def _generate_examples(self, filepath: Path, language: str):
+        """Yields examples as (key, example) tuples."""
+
+        if language == "nxe" and self.config.schema == "source":
+            if "_".join(self.config.name.split("_")[4:6]) == "nxe_eng":
+                words, _ = self._get_word_(filepath)
+            else:
+                _, words = self._get_word_(filepath)
+
+            for item in words:
+                for idx, word in enumerate(item):
+                    row = {"id": str(idx), "word": word}
+                    yield idx, row
+
+        else:
+            source_data, target_data = self._get_sentence_(filepath)
+            for idx, (source, target) in enumerate(zip(source_data, target_data)):
+                if self.config.schema == "source":
+                    example = {"source_sentence": source, "target_sentence": target, "source_lang": "eng", "target_lang": language}
+                elif self.config.schema == f"seacrowd_{self.SEACROWD_SCHEMA_NAME}":
+                    example = {
+                        "id": str(idx),
+                        "text_1": source,
+                        "text_2": target,
+                        "text_1_name": "eng",
+                        "text_2_name": language,
+                    }
+                yield idx, example
+
+    def _get_sentence_(self, path_dict) -> Tuple[List, List]:
+        source_data = []
+        target_data = []
+        for _, v in path_dict.items():
+            with open(v, "r", encoding="utf-8") as f:
+                data = f.readlines()
+            src, trg = processing.parse_text(data)
+            source_data.extend(src)
+            target_data.extend(trg)
+
+        return source_data, target_data
+
+    def _get_word_(self, path_dict) -> Tuple[List, List]:
+        eng_data, ind_data, nage_data = [], [], []
+        for _, v in path_dict.items():
+            with open(v, "r", encoding="utf-8") as f:
+                data = f.readlines()
+            eng_word, ind_word, nage_word = processing.parse_wordlist(data)
+            eng_data.append(eng_word)
+            ind_data.append(ind_word)
+            nage_data.append(nage_word)
+
+        return eng_data, nage_data

--- a/seacrowd/sea_datasets/lio_and_central_flores/path_url.py
+++ b/seacrowd/sea_datasets/lio_and_central_flores/path_url.py
@@ -1,0 +1,59 @@
+_URLS_DICT = {
+    "LIO": {
+        "LIO_ave_maria_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_5fabcbda_6835_4ae3_b66f_21daae70d7b6/datastream/OBJ/download",
+        },
+        "LIO_positional_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_c1c1b5d6_d607_44c2_8f39_cda2041275aa/datastream/OBJ/download"
+        },
+        "LIO_frogstory_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_f290b09f_c351_46fe_8d86_d2ac624294c1/datastream/OBJ/download"
+        },
+        "LIO_frogstory_stan_jaya_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_1f24eace_b603_46f4_96d0_0054305caaf6/datastream/OBJ/download"
+        },
+        "LIO_history_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_b3b9b4de_a76e_440d_bf03_12c51ddc7954/datastream/OBJ/download"
+        },
+        "LIO_scorpion_story_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_d3b552ce_72d4_4d94_8510_8626b5cb91da/datastream/OBJ/download"
+        },
+        "LIO_our_father_transcription": {
+             "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_50477a6a_12c6_4ae1_976a_9770f356062e/datastream/OBJ/download"
+        },
+        "LIO_credo_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_90f05ac6_813b_4570_b25c_f8d8b12bf8f0/datastream/OBJ/download"
+        },
+        "LIO_father_son_holy_spirit":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_9016339d_164f_464e_8653_9d941dd622b4/datastream/OBJ/download"
+        },
+        "LIO_glory_be_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_9a5f906c_bd51_40a3_a07a_39a99bb21d5a/datastream/OBJ/download"
+        },
+        "LIO_sambal_recipe_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_c2c00068_d01e_4ee3_877d_b42e1b0e77c5/datastream/OBJ/download"
+        },
+        "LIO_bridewealth_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_02e08440_721c_4a04_9ca5_7c9fb86eca2d/datastream/OBJ/download"
+        },
+        "LIO_gawi_kelimutu_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_d1e32c05_4e58_4171_9c59_0b394a13dc0b/datastream/OBJ/download"
+        },
+        "LIO_song_ine_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_d504e40b_e70e_4062_b406_8d69e162d392/datastream/OBJ/download"
+        }
+    },
+    "ENDE": {
+        "ENDE_positional_transcription": {
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_1655f827_74d6_47c9_83eb_c9be02a3ac3d/datastream/OBJ/download"
+        },
+        "ENDE_frogstory_transcription":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_b990239e_6229_4c58_96c3_71755040a8bb/datastream/OBJ/download"
+        }
+    },
+    "NAGE":{
+        "Nage_Ondorea_Barat_Lexirumah_Wordlist_Original":{
+            "text_path": "https://archive.mpi.nl/tla/islandora/object/tla%3A1839_34f3575a_f83f_4674_a1ac_8abd0006e151/datastream/OBJ/download"
+        }
+    }
+}

--- a/seacrowd/sea_datasets/lio_and_central_flores/processing.py
+++ b/seacrowd/sea_datasets/lio_and_central_flores/processing.py
@@ -1,0 +1,55 @@
+import re
+
+def parse_text(data):
+    cleaned_data = [re.sub(r'^\ufeff?\d+\t|\b\d+\)\s*', '', re.sub(r'\t+', '\t', text)).replace('\t\n', '').replace('\ufeff', '') for text in data]
+
+    result, sublist = [], []
+    for item in cleaned_data:
+        item = item.replace('\t', ' ')
+        if item != '':
+            sublist.append(item)
+        else:
+            if sublist:
+                result.append(sublist)
+                sublist = []
+
+    if sublist:
+        result.append(sublist)
+
+    lio_data = []
+    eng_data = []
+
+    for i in result:
+      if len(i) == 2:
+        lio_data.append(i[0])
+        eng_data.append(i[1])
+      elif len(i) == 3:
+        lio_data.append(i[0])
+        eng_data.append(i[2])
+      elif len(i) == 4:
+        lio_data.append(i[1])
+        eng_data.append(i[3])
+        
+    return eng_data, lio_data
+
+def parse_wordlist(data):
+    """
+    untuk Nage
+    """
+    cleaned_data = [re.sub(r'^\ufeff?\d+\t|\b\d+\)\s*', '', re.sub(r'\t+', '\t', text)).replace('\t\n', '').replace('\ufeff', '') for text in data]
+    cleaned_data = [elem for elem in cleaned_data if elem != '']
+    
+    eng_word = []
+    nage_word = []
+    ind_word = []
+    for item in cleaned_data:
+        split_data = item.split()
+        if len(split_data) == 3:
+            eng_word.append(split_data[0])
+            nage_word.append(split_data[2])
+            ind_word.append(split_data[1])
+            
+    return eng_word, ind_word, nage_word
+
+
+

--- a/seacrowd/sea_datasets/lio_and_central_flores/processing.py
+++ b/seacrowd/sea_datasets/lio_and_central_flores/processing.py
@@ -1,55 +1,75 @@
 import re
 
+
+import re
+
 def parse_text(data):
+    """
+    Parses a list of text data into English and Lio language lists.
+
+    Args:
+        data (list): A list of strings containing text data.
+
+    Returns:
+        tuple: A tuple containing two lists: English language data and Lio language data.
+    """
+    # Clean the data by removing unwanted characters and formatting
     cleaned_data = [re.sub(r'^\ufeff?\d+\t|\b\d+\)\s*', '', re.sub(r'\t+', '\t', text)).replace('\t\n', '').replace('\ufeff', '') for text in data]
 
-    result, sublist = [], []
+    # Split the data into English and Lio lists
+    eng_data, lio_data = [], []
+    sublist = []
+
     for item in cleaned_data:
+        # Replace tabs with spaces
         item = item.replace('\t', ' ')
         if item != '':
             sublist.append(item)
         else:
             if sublist:
-                result.append(sublist)
+                # Append sublist to result if not empty
+                eng_data.append(sublist[-1])
+                lio_data.append(sublist[0])
                 sublist = []
 
+    # Append the remaining sublist if any
     if sublist:
-        result.append(sublist)
+        eng_data.append(sublist[-1])
+        lio_data.append(sublist[0])
 
-    lio_data = []
-    eng_data = []
-
-    for i in result:
-      if len(i) == 2:
-        lio_data.append(i[0])
-        eng_data.append(i[1])
-      elif len(i) == 3:
-        lio_data.append(i[0])
-        eng_data.append(i[2])
-      elif len(i) == 4:
-        lio_data.append(i[1])
-        eng_data.append(i[3])
-        
     return eng_data, lio_data
 
 def parse_wordlist(data):
     """
-    untuk Nage
+    Parses a word list for translation into English, Indonesian, and Nage languages.
+
+    Args:
+        data (list): A list of strings containing word list data.
+
+    Returns:
+        tuple: A tuple containing three lists: English words, Indonesian words, and Nage words.
     """
+    # Clean the data by removing unwanted characters and formatting
     cleaned_data = [re.sub(r'^\ufeff?\d+\t|\b\d+\)\s*', '', re.sub(r'\t+', '\t', text)).replace('\t\n', '').replace('\ufeff', '') for text in data]
+    
+    # Remove empty elements
     cleaned_data = [elem for elem in cleaned_data if elem != '']
     
     eng_word = []
     nage_word = []
     ind_word = []
+    
     for item in cleaned_data:
         split_data = item.split()
-        if len(split_data) == 3:
+        # make sure that we only get [eng, ind, nage] because the actual wordlist have 
+        # added 'comment' column and not all the words have their comments
+        if len(split_data) == 3: 
             eng_word.append(split_data[0])
-            nage_word.append(split_data[2])
             ind_word.append(split_data[1])
-            
+            nage_word.append(split_data[2])
+
     return eng_word, ind_word, nage_word
+
 
 
 


### PR DESCRIPTION
Closes #312 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.