### PR TITLE
Closes #513 | Add Dataloader GNOME

### DIFF
--- a/seacrowd/sea_datasets/gnome/gnome.py
+++ b/seacrowd/sea_datasets/gnome/gnome.py
@@ -1,0 +1,190 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import requests
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import SCHEMA_TO_FEATURES, TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = r"""\
+@inproceedings{tiedemann-2012-parallel,
+    title = "Parallel Data, Tools and Interfaces in {OPUS}",
+    author = {Tiedemann, J{\"o}rg},
+    editor = "Calzolari, Nicoletta  and
+        Choukri, Khalid  and
+        Declerck, Thierry  and
+        Do{\u{g}}an, Mehmet U{\u{g}}ur  and
+        Maegaard, Bente  and
+        Mariani, Joseph  and
+        Moreno, Asuncion  and
+        Odijk, Jan  and
+        Piperidis, Stelios",
+    booktitle = "Proceedings of the Eighth International Conference on Language
+    Resources and Evaluation ({LREC}'12)",
+    month = may,
+    year = "2012",
+    address = "Istanbul, Turkey",
+    publisher = "European Language Resources Association (ELRA)",
+    url = "http://www.lrec-conf.org/proceedings/lrec2012/pdf/463_Paper.pdf",
+    pages = "2214--2218",
+    abstract = "This paper presents the current status of OPUS, a growing
+    language resource of parallel corpora and related tools. The focus in OPUS
+    is to provide freely available data sets in various formats together with
+    basic annotation to be useful for applications in computational linguistics,
+    translation studies and cross-linguistic corpus studies. In this paper, we
+    report about new data sets and their features, additional annotation tools
+    and models provided from the website and essential interfaces and on-line
+    services included in the project.",
+}
+"""
+
+_DATASETNAME = "gnome"
+
+_DESCRIPTION = """\
+A parallel corpus of GNOME localization files, which contains the interface text
+in the GNU Network Object Model Environment (GNOME) and published by GNOME
+translation teams. Text in this dataset is relatively short and technical.
+"""
+
+_HOMEPAGE = "https://opus.nlpl.eu/GNOME/corpus/version/GNOME"
+
+_LANGUAGES = ["eng", "vie", "mya", "ind", "tha", "tgl", "zlm", "lao"]
+_SUBSETS = ["en", "vi", "my", "id", "th", "tl", "ms", "lo"]
+_SUBSET_PAIRS = [(src, tgt) for src in _SUBSETS for tgt in _SUBSETS if src != tgt]
+
+_LICENSE = Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_URLS = {
+    "api": "http://opus.nlpl.eu/opusapi/?source={src_lang}&target={tgt_lang}&corpus=GNOME&version=v1",
+    "data": "https://object.pouta.csc.fi/OPUS-GNOME/v1/moses/{lang_pair}.txt.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # t2t
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class GnomeDataset(datasets.GeneratorBasedBuilder):
+    """A parallel corpus of GNOME localization files"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset in _SUBSET_PAIRS:
+        lang_pair = f"{subset[0]}-{subset[1]}"
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{lang_pair}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {lang_pair} source schema",
+                schema="source",
+                subset_id=lang_pair,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{lang_pair}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {lang_pair} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=lang_pair,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = (
+        f"{_DATASETNAME}_{_SUBSET_PAIRS[0][0]}-{_SUBSET_PAIRS[0][1]}_source"
+    )
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "source": datasets.Value("string"),
+                    "target": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        src_lang, tgt_lang = self.config.subset_id.split("-")
+        api_url = _URLS["api"].format(src_lang=src_lang, tgt_lang=tgt_lang)
+        data_url = None
+
+        response = requests.get(api_url, timeout=10)
+        if response:
+            corpora = response.json()["corpora"]
+            for corpus in corpora:
+                if ".txt.zip" in corpus["url"]:
+                    data_url = corpus["url"]
+                    break
+        else:
+            raise requests.exceptions.HTTPError(
+                f"Non-success status code: {response.status_code}"
+            )
+
+        if not data_url:
+            raise ValueError(f"No suitable corpus found, check {api_url}")
+        else:
+            lang_pair = data_url.split("/")[-1].split(".")[0]
+            data_dir = Path(dl_manager.download_and_extract(data_url))
+            src_file = data_dir / f"GNOME.{lang_pair}.{src_lang}"
+            tgt_file = data_dir / f"GNOME.{lang_pair}.{tgt_lang}"
+
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "src_file": src_file,
+                        "tgt_file": tgt_file,
+                    },
+                ),
+            ]
+
+    def _generate_examples(self, src_file: Path, tgt_file: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(src_file, "r", encoding="utf-8") as src_f, open(
+            tgt_file, "r", encoding="utf-8"
+        ) as tgt_f:
+            for idx, (src_line, tgt_line) in enumerate(zip(src_f, tgt_f)):
+                if self.config.schema == "source":
+                    yield idx, {"source": src_line.strip(), "target": tgt_line.strip()}
+                elif self.config.schema == _SEACROWD_SCHEMA:
+                    yield idx, {
+                        "id": str(idx),
+                        "text_1": src_line.strip(),
+                        "text_2": tgt_line.strip(),
+                        "text_1_name": f"source ({src_file.name.split('.')[-1]})",
+                        "text_2_name": f"target ({tgt_file.name.split('.')[-1]})",
+                    }


### PR DESCRIPTION
Closes #513

Based on discussion [#456](https://github.com/SEACrowd/seacrowd-datahub/pull/456#issuecomment-1978320893), I implemented all possible language pairs listed on the datasheet.
> For parallel MT dataloaders, we agreed upon having a subset for every possible direction with at least 1 SEA language.

Thus, configs will look like this: `gnome_en-id_source`, `gnome_tl-vi_seacrowd_t2t`, etc. When testing, pass `gnome_<subset>` to the `--subset_id` parameter.


<details close>
  <summary>Here is a useful script to test all possible language pairs:</summary>

To run this script, save it to a file (e.g., `gnome_tests.sh`), make it executable with `chmod +x gnome_tests.sh`, and execute it with `./gnome_tests.sh`. Ensure you run the script from the seacrowd root directory.

```bash
#!/bin/bash

mkdir -p data/gnome
SUBSETS=("en" "vi" "my" "id" "th" "tl" "ms" "lo")
success_count=0
fail_count=0
declare -a failed_tests

for src_lang in "${SUBSETS[@]}"; do
    for tgt_lang in "${SUBSETS[@]}"; do
        if [ "$src_lang" != "$tgt_lang" ]; then
            lang_pair="${src_lang}-${tgt_lang}"
            python_command="python -m tests.test_seacrowd seacrowd/sea_datasets/gnome/gnome.py --subset_id=gnome_${lang_pair}"
            output_file="data/gnome/${lang_pair}.txt"
            temp_output_file="data/gnome/${lang_pair}_temp.txt"  # for cleaner cli output

            echo "Testing language pair: $lang_pair"
            # run the test, save the output, and redirect verbose output to a temporary file
            script -q -c "$python_command" "$temp_output_file" > /dev/null
            cat "$temp_output_file" > "$output_file"
            rm "$temp_output_file"

            # check if the test was successful
            if grep -q "OK" "$output_file"; then
                echo "Test for $lang_pair: SUCCESS"
                ((success_count++))
            else
                echo "Test for $lang_pair: FAILURE"
                failed_tests+=("$lang_pair")
                ((fail_count++))
            fi
        fi
    done
done

echo "-----------------------"
echo "SUMMARY: $((success_count + fail_count)) tests total"
echo "Success: $success_count"
echo "Failure: $fail_count"
if [ ${#failed_tests[@]} -gt 0 ]; then
    echo "Failed tests:"
    for test in "${failed_tests[@]}"; do
        echo "- $test"
    done
fi
```
</details>


This is the intended test result summary:
```
SUMMARY: 56 tests total
Success: 50
Failure: 6
Failed tests:
- my-tl
- my-lo
- tl-my
- tl-lo
- lo-my
- lo-tl
```

The failed tests above are due to the absence of a suitable corpus, as determined by checking the OPUS API (see the dataloader implementation). I have included the failed subsets instead of listing subset exceptions in the datasheet later on, and it is better that way IMO.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.