### PR TITLE
Closes #524 | Add Dataloader HPLT

### DIFF
--- a/seacrowd/sea_datasets/hplt/hplt.py
+++ b/seacrowd/sea_datasets/hplt/hplt.py
@@ -92,6 +92,7 @@ _LANGUAGES = {
     "tha": "th",
     "mya": "my",
     "fil": "tl",
+    "vie": "vi"
 }
 
 _LICENSE = Licenses.CC0_1_0.value

--- a/seacrowd/sea_datasets/hplt/hplt.py
+++ b/seacrowd/sea_datasets/hplt/hplt.py
@@ -86,7 +86,13 @@ models and workflows at scale using high-performance computing (HPC).
 
 _HOMEPAGE = "https://hplt-project.org/datasets/v1.2"
 
-_LANGUAGES = ["ind", "zlm", "tha", "mya", "fil"]
+_LANGUAGES = {
+    "ind": "id",
+    "zlm": "ms",
+    "tha": "th",
+    "mya": "my",
+    "fil": "tl",
+}
 
 _LICENSE = Licenses.CC0_1_0.value
 
@@ -111,11 +117,11 @@ class HpltDataset(datasets.GeneratorBasedBuilder):
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
-    LANGS = ["id", "ms", "th", "my", "tl"]
+
     SUBSETS = ["raw", "deduplicated", "cleaned"]
 
     BUILDER_CONFIGS = []
-    for lang, subset in list(itertools.product(LANGS, SUBSETS)):
+    for lang, subset in list(itertools.product(_LANGUAGES.keys(), SUBSETS)):
         subset_id = f"{lang}_{subset}"
         BUILDER_CONFIGS += [
             SEACrowdConfig(
@@ -134,7 +140,7 @@ class HpltDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_my_cleaned_source"  # smallest w.r.t. size
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_mya_cleaned_source"  # smallest w.r.t. size
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -165,6 +171,7 @@ class HpltDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators. Data is not yet extracted for efficient generation."""
         lang, subset = self.config.subset_id.split("_")
+        lang = _LANGUAGES[lang]
         map_url = _URLS[subset].format(lang=lang)
 
         response = requests.get(map_url, timeout=10)

--- a/seacrowd/sea_datasets/hplt/hplt.py
+++ b/seacrowd/sea_datasets/hplt/hplt.py
@@ -1,0 +1,217 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import itertools
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import requests
+import zstandard as zstd
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import SCHEMA_TO_FEATURES, TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = r"""\
+@inproceedings{aulamo-etal-2023-hplt,
+    title = "{HPLT}: High Performance Language Technologies",
+    author = {Aulamo, Mikko  and
+        Bogoychev, Nikolay  and
+        Ji, Shaoxiong  and
+        Nail, Graeme  and
+        Ram{\'\i}rez-S{\'a}nchez, Gema  and
+        Tiedemann, J{\"o}rg  and
+        van der Linde, Jelmer  and
+        Zaragoza, Jaume},
+    editor = "Nurminen, Mary  and
+        Brenner, Judith  and
+        Koponen, Maarit  and
+        Latomaa, Sirkku  and
+        Mikhailov, Mikhail  and
+        Schierl, Frederike  and
+        Ranasinghe, Tharindu  and
+        Vanmassenhove, Eva  and
+        Vidal, Sergi Alvarez  and
+        Aranberri, Nora  and
+        Nunziatini, Mara  and
+        Escart{\'\i}n, Carla Parra  and
+        Forcada, Mikel  and
+        Popovic, Maja  and
+        Scarton, Carolina  and
+        Moniz, Helena",
+    booktitle = "Proceedings of the 24th Annual Conference of the European
+    Association for Machine Translation",
+    month = jun,
+    year = "2023",
+    address = "Tampere, Finland",
+    publisher = "European Association for Machine Translation",
+    url = "https://aclanthology.org/2023.eamt-1.61",
+    pages = "517--518",
+
+    abstract = "We describe the High Performance Language Technologies project
+    (HPLT), a 3-year EU-funded project started in September 2022. HPLT will
+    build a space combining petabytes of natural language data with large-scale
+    model training. It will derive monolingual and bilingual datasets from the
+    Internet Archive and CommonCrawl and build efficient and solid machine
+    translation (MT) as well as large language models (LLMs). HPLT aims at
+    providing free, sustainable and reusable datasets, models and workflows at
+    scale using high-performance computing (HPC).",
+}
+"""
+
+_DATASETNAME = "hplt"
+
+_DESCRIPTION = """\
+The dataset is part of the High Performance Language Technologies project
+(HPLT), a 3-year EU-funded project started in September 2022. HPLT derives
+monolingual and bilingual datasets from the Internet Archive and CommonCrawl and
+builds efficient and solid machine translation (MT) as well as large language
+models (LLMs). HPLT aims at providing free, sustainable and reusable datasets,
+models and workflows at scale using high-performance computing (HPC).
+"""
+
+_HOMEPAGE = "https://hplt-project.org/datasets/v1.2"
+
+_LANGUAGES = ["ind", "zlm", "tha", "mya", "fil"]
+
+_LICENSE = Licenses.CC0_1_0.value
+
+_LOCAL = False
+
+_URLS = {
+    "raw": "https://data.hplt-project.org/one/monotext/{lang}_map.txt",
+    "deduplicated": "https://data.hplt-project.org/one/monotext/deduplicated/{lang}_map.txt",
+    "cleaned": "https://data.hplt-project.org/one/monotext/cleaned/{lang}_map.txt",
+}
+
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # ssp
+
+_SOURCE_VERSION = "1.2.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class HpltDataset(datasets.GeneratorBasedBuilder):
+    """HPLT derives monolingual and bilingual datasets from the Internet Archive and CommonCrawl"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+    LANGS = ["id", "ms", "th", "my", "tl"]
+    SUBSETS = ["raw", "deduplicated", "cleaned"]
+
+    BUILDER_CONFIGS = []
+    for lang, subset in list(itertools.product(LANGS, SUBSETS)):
+        subset_id = f"{lang}_{subset}"
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset_id}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {subset_id} source schema",
+                schema="source",
+                subset_id=subset_id,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset_id}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {subset_id} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=subset_id,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_my_cleaned_source"  # smallest w.r.t. size
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("int32"),
+                    "document_lang": datasets.Value("string"),
+                    "scores": datasets.Sequence(datasets.Value("float")),
+                    "langs": datasets.Sequence(datasets.Value("string")),
+                    "text": datasets.Value("string"),
+                    "url": datasets.Value("string"),
+                    "collection": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # ssp_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators. Data is not yet extracted for efficient generation."""
+        lang, subset = self.config.subset_id.split("_")
+        map_url = _URLS[subset].format(lang=lang)
+
+        response = requests.get(map_url, timeout=10)
+        if response:
+            data_urls = response.text.strip().split("\n")
+            data_urls = [url for url in data_urls if url.endswith(".jsonl.zst")]
+        else:
+            raise requests.exceptions.HTTPError(
+                f"Non-success status code: {response.status_code}"
+            )
+
+        data_paths = list(map(Path, dl_manager.download(data_urls)))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_paths": data_paths,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_paths: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        key = 0
+        for data_path in data_paths:
+            with open(data_path, "rb") as f:
+                # Zstandard decompression
+                dctx = zstd.ZstdDecompressor()
+                reader = dctx.stream_reader(f)
+                text_io = io.TextIOWrapper(reader, encoding="utf-8")
+
+                # read jsonl file by line and yield
+                for line in text_io:
+                    data = json.loads(line)
+                    if self.config.schema == "source":
+                        yield key, {
+                            "id": key,
+                            "document_lang": data["document_lang"],
+                            "scores": data["scores"],
+                            "langs": data["langs"],
+                            "text": data["text"],
+                            "url": data["url"],
+                            "collection": data["collection"],
+                        }
+                    elif self.config.schema == _SEACROWD_SCHEMA:
+                        yield key, {
+                            "id": str(key),
+                            "text": data["text"],
+                        }
+                    key += 1


### PR DESCRIPTION
Closes #524

I implemented one config per language+subset. Thus, configs will look like this: `hplt_id_raw_source`, `hplt_my_cleaned_seacrowd_ssp`, etc. When testing, pass `hplt_<subset>` to the `--subset_id` parameter.

Due to the huge size, it may take some time to download the data. For efficient testing, I suggest testing by copying some part of this code and using either of these subsets: `my_cleaned` (smallest seacrowd subset), `cy_cleaned` (smallest one-file-dataset), or `sk_cleaned` (smallest two-files-dataset) if you're interested.

Just a heads-up, I noticed `vie` language is included in the dataset's [supported languages](https://huggingface.co/datasets/HPLT/hplt_monolingual_v1_2#supported-languages) but not listed in datasheet #524. I haven't checked for other possible unlisted languages and also have not implemented that here in the dataloader. Just waiting for further instructions.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.