### PR TITLE
Closes #537 | Add Dataloader Bud500

### DIFF
--- a/seacrowd/sea_datasets/bud500/bud500.py
+++ b/seacrowd/sea_datasets/bud500/bud500.py
@@ -165,10 +165,10 @@ class Bud500Dataset(datasets.GeneratorBasedBuilder):
                         elif self.config.schema == _SEACROWD_SCHEMA:
                             yield key, {
                                 "id": str(key),
-                                # "path": None,
+                                "path": None,
                                 "audio": row.audio,
                                 "text": row.transcription,
-                                # "speaker_id": None,
-                                # "metadata": None,
+                                "speaker_id": None,
+                                "metadata": None,
                             }
                         key += 1

--- a/seacrowd/sea_datasets/bud500/bud500.py
+++ b/seacrowd/sea_datasets/bud500/bud500.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+from huggingface_hub import HfFileSystem
+from pyarrow import parquet as pq
+
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import SCHEMA_TO_FEATURES, TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = """\
+@misc{Bud500,
+    author = {Anh Pham, Khanh Linh Tran, Linh Nguyen, Thanh Duy Cao, Phuc Phan, Duong A. Nguyen},
+    title = {Bud500: A Comprehensive Vietnamese ASR Dataset},
+    url = {https://github.com/quocanh34/Bud500},
+    year = {2024}
+}
+"""
+
+_DATASETNAME = "bud500"
+
+_DESCRIPTION = """\
+Bud500 is a diverse Vietnamese speech corpus designed to support ASR research
+community. With aprroximately 500 hours of audio, it covers a broad spectrum of
+topics including podcast, travel, book, food, and so on, while spanning accents
+from Vietnam's North, South, and Central regions. Derived from free public audio
+resources, this publicly accessible dataset is designed to significantly enhance
+the work of developers and researchers in the field of speech recognition.
+Before using this dataloader, please accept the acknowledgement at
+https://huggingface.co/datasets/linhtran92/viet_bud500 and use huggingface-cli
+login for authentication.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/linhtran92/viet_bud500"
+
+_LANGUAGES = ["vie"]
+
+_LICENSE = Licenses.APACHE_2_0.value
+
+_LOCAL = False
+
+_BASE_URL = "https://huggingface.co/datasets/linhtran92/viet_bud500/resolve/main/data/{filename}"
+
+_SUPPORTED_TASKS = [Tasks.SPEECH_RECOGNITION]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # sptext
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class Bud500Dataset(datasets.GeneratorBasedBuilder):
+    """A diverse Vietnamese speech corpus with aprroximately 500 hours of audio."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{_SEACROWD_SCHEMA}",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema=_SEACROWD_SCHEMA,
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "audio": datasets.Audio(sampling_rate=16_000),
+                    "transcription": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = SCHEMA_TO_FEATURES[
+                TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]]
+            ]  # speech_text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        file_list = HfFileSystem().ls("datasets/linhtran92/viet_bud500/data", detail=False)
+        train_urls, test_urls, val_urls = [], [], []
+
+        for filename in file_list:
+            if filename.endswith(".parquet"):
+                filename = filename.split("/")[-1]
+                split = filename.split("-")[0]
+                url = _BASE_URL.format(filename=filename)
+
+                if split == "train":
+                    train_urls.append(url)
+                elif split == "test":
+                    test_urls.append(url)
+                elif split == "validation":
+                    val_urls.append(url)
+
+        train_paths = list(map(Path, dl_manager.download(sorted(train_urls))))
+        test_paths = list(map(Path, dl_manager.download(sorted(test_urls))))
+        val_paths = list(map(Path, dl_manager.download(sorted(val_urls))))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_paths": train_paths},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_paths": test_paths},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_paths": val_paths},
+            ),
+        ]
+
+    def _generate_examples(self, data_paths: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        key = 0
+        for data_path in data_paths:
+            with open(data_path, "rb") as f:
+                pf = pq.ParquetFile(f)
+
+                for row_group in range(pf.num_row_groups):
+                    df = pf.read_row_group(row_group).to_pandas()
+
+                    for row in df.itertuples():
+                        if self.config.schema == "source":
+                            yield key, {
+                                "audio": row.audio,
+                                "transcription": row.transcription,
+                            }
+                        elif self.config.schema == _SEACROWD_SCHEMA:
+                            yield key, {
+                                "id": str(key),
+                                # "path": None,
+                                "audio": row.audio,
+                                "text": row.transcription,
+                                # "speaker_id": None,
+                                # "metadata": None,
+                            }
+                        key += 1


### PR DESCRIPTION
Closes #537

This dataset is MASSIVE, and it seems the seacrowd test must download ALL data for it to be _OK_. I downloaded and loaded all the files (~100gb) and successfully tested it. I'm putting the result here: [bud500.txt](https://github.com/SEACrowd/seacrowd-datahub/files/14817853/bud500.txt)

For those with limited internet quota, I'm suggesting to load the data in Python's REPL, passing `streaming=True` as follows:
```python
>>> from datasets import load_dataset
>>> 
>>> data = load_dataset("seacrowd/sea_datasets/bud500", name="bud500_source", split="train", streaming=True)
>>> list(data.take(3))
[{'audio': {'path': None, 'array': array([ 0.04827881, ..., -0.08636475]), 'sampling_rate': 16000}, 'transcription': 'thế mà hôm nay lại nghe em gái nhắc đến'},
 {'audio': {'path': None, 'array': array([-0.01934814, ...,  0.38327026]), 'sampling_rate': 16000}, 'transcription': 'các vấn đề y học chuyên khoa hoặc ứng'},
 {'audio': {'path': None, 'array': array([-0.23605347, ...,  0.0322876 ]), 'sampling_rate': 16000}, 'transcription': 'không được về nhà ăn tết thì là năm nay'}]
>>> 
>>> data = load_dataset("seacrowd/sea_datasets/bud500", name="bud500_seacrowd_sptext", split="test", streaming=True)
>>> list(data.take(3))
[{'id': '0', 'path': None, 'audio': {'path': None, 'array': array([0.02420044 , ..., 0.05227661 ]), 'sampling_rate': 16000}, 'text': 'tôi thì tôi nghĩ rằng là hầu hết tất cả', 'speaker_id': None, 'metadata': None},
 {'id': '1', 'path': None, 'audio': {'path': None, 'array': array([-0.00128174, ..., -0.14556885]), 'sampling_rate': 16000}, 'text': 'khách du lịch quốc tế và trong nước bốn', 'speaker_id': None, 'metadata': None},
 {'id': '2', 'path': None, 'audio': {'path': None, 'array': array([-0.00796509, ..., -0.06576538]), 'sampling_rate': 16000}, 'text': 'sơn đang làm ở việt nam', 'speaker_id': None, 'metadata': None}]
```

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.