### PR TITLE
Closes #583 | Add Dataloader multilingual-NLI-26lang-2mil7

### DIFF
--- a/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
+++ b/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+from huggingface_hub import HfFileSystem
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import TASK_TO_SCHEMA, Licenses, Tasks
+
+_CITATION = """\
+@article{laurer_less_2022,
+    title = {Less Annotating, More Classifying: Addressing the Data Scarcity
+    Issue of Supervised Machine Learning with Deep Transfer Learning and
+    BERT-NLI},
+    url = {https://osf.io/74b8k},
+    language = {en-us},
+    urldate = {2022-07-28},
+    journal = {Preprint},
+    author = {Laurer, Moritz and
+        Atteveldt, Wouter van and
+        Casas, Andreu Salleras and
+        Welbers, Kasper},
+    month = jun,
+    year = {2022},
+    note = {Publisher: Open Science Framework},
+}
+"""
+
+_DATASETNAME = "multilingual_nli_26lang"
+
+_DESCRIPTION = """\
+This dataset contains 2 730 000 NLI text pairs in 26 languages spoken by more
+than 4 billion people. The dataset can be used to train models for multilingual
+NLI (Natural Language Inference) or zero-shot classification. The dataset is
+based on the English datasets MultiNLI, Fever-NLI, ANLI, LingNLI and WANLI and
+was created using the latest open-source machine translation models.
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/MoritzLaurer/multilingual-NLI-26lang-2mil7"
+
+_LANGUAGES = ["ind", "vie"]
+
+_LICENSE = Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_BASE_URL = "https://huggingface.co/datasets/MoritzLaurer/multilingual-NLI-26lang-2mil7/resolve/main/data/{file_name}"
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+_SEACROWD_SCHEMA = f"seacrowd_{TASK_TO_SCHEMA[_SUPPORTED_TASKS[0]].lower()}"  # pairs
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class MultilingualNLI26LangDataset(datasets.GeneratorBasedBuilder):
+    """NLI dataset in 26 languages, created using machine translation models"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    LANGS = ["id", "vi"]
+    SUBSETS = ["anli", "fever", "ling", "mnli", "wanli"]
+
+    BUILDER_CONFIGS = []
+    for lang, subset in list(itertools.product(LANGS, SUBSETS)):
+        subset_id = f"{lang}_{subset}"
+        BUILDER_CONFIGS += [
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset_id}_source",
+                version=SOURCE_VERSION,
+                description=f"{_DATASETNAME} {subset_id} source schema",
+                schema="source",
+                subset_id=subset_id,
+            ),
+            SEACrowdConfig(
+                name=f"{_DATASETNAME}_{subset_id}_{_SEACROWD_SCHEMA}",
+                version=SEACROWD_VERSION,
+                description=f"{_DATASETNAME} {subset_id} SEACrowd schema",
+                schema=_SEACROWD_SCHEMA,
+                subset_id=subset_id,
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_id_anli_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "premise_original": datasets.Value("string"),
+                    "hypothesis_original": datasets.Value("string"),
+                    "label": datasets.Value("int64"),
+                    "premise": datasets.Value("string"),
+                    "hypothesis": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == _SEACROWD_SCHEMA:
+            features = schemas.pairs_features(label_names=["entailment", "neutral", "contradiction"])
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        file_list = HfFileSystem().ls("datasets/MoritzLaurer/multilingual-NLI-26lang-2mil7/data", detail=False)
+
+        data_urls = []
+        for file_path in file_list:
+            file_name = file_path.split("/")[-1]
+            subset_id = file_name.split("-")[0]
+            if subset_id == self.config.subset_id:
+                if file_path.endswith(".parquet"):
+                    url = _BASE_URL.format(file_name=file_name)
+                    data_urls.append(url)
+        
+        data_paths = list(map(Path, dl_manager.download_and_extract(data_urls)))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_paths": data_paths,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_paths: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        key = 0
+        for data_path in data_paths:
+            df = pd.read_parquet(data_path)
+
+            for _, row in df.iterrows():
+                if self.config.schema == "source":
+                    yield key, {
+                        "premise_original": row["premise_original"],
+                        "hypothesis_original": row["hypothesis_original"],
+                        "label": row["label"],
+                        "premise": row["premise"],
+                        "hypothesis": row["hypothesis"],
+                    }
+                    key += 1
+                elif self.config.schema == _SEACROWD_SCHEMA:
+                    yield key, {
+                        "id": str(key),
+                        "text_1": row["premise"],
+                        "text_2": row["hypothesis"],
+                        "label": row["label"],
+                    }
+                    key += 1

--- a/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
+++ b/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
@@ -142,7 +142,7 @@ class MultilingualNLI26LangDataset(datasets.GeneratorBasedBuilder):
                 if file_path.endswith(".parquet"):
                     url = _BASE_URL.format(file_name=file_name)
                     data_urls.append(url)
-        
+
         data_paths = list(map(Path, dl_manager.download_and_extract(data_urls)))
         return [
             datasets.SplitGenerator(

--- a/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
+++ b/seacrowd/sea_datasets/multilingual_nli_26lang/multilingual_nli_26lang.py
@@ -78,11 +78,10 @@ class MultilingualNLI26LangDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
-    LANGS = ["id", "vi"]
     SUBSETS = ["anli", "fever", "ling", "mnli", "wanli"]
 
     BUILDER_CONFIGS = []
-    for lang, subset in list(itertools.product(LANGS, SUBSETS)):
+    for lang, subset in list(itertools.product(_LANGUAGES, SUBSETS)):
         subset_id = f"{lang}_{subset}"
         BUILDER_CONFIGS += [
             SEACrowdConfig(
@@ -101,7 +100,7 @@ class MultilingualNLI26LangDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_id_anli_source"
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_ind_anli_source"
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":
@@ -129,11 +128,17 @@ class MultilingualNLI26LangDataset(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         file_list = HfFileSystem().ls("datasets/MoritzLaurer/multilingual-NLI-26lang-2mil7/data", detail=False)
 
+        subset_config = self.config.subset_id
+        if "ind" in subset_config:
+            subset_config = subset_config.replace("ind", "id")
+        if "vie" in subset_config:
+            subset_config = subset_config.replace("vie", "vi")
+
         data_urls = []
         for file_path in file_list:
             file_name = file_path.split("/")[-1]
             subset_id = file_name.split("-")[0]
-            if subset_id == self.config.subset_id:
+            if subset_id == subset_config:
                 if file_path.endswith(".parquet"):
                     url = _BASE_URL.format(file_name=file_name)
                     data_urls.append(url)


### PR DESCRIPTION
Closes #583 

There are 10 subsets. Configs will look like this: `multilingual_nli_26lang_id_anli_source`, `multilingual_nli_26lang_vi_ling_seacrowd_pairs`, etc. When testing, pass `multilingual_nli_26lang_<subset>` to the `--subset_id` parameter.


<details close>
  <summary>Here is a useful script to test all subsets:</summary>

To run this script, save it to a file (e.g., `mnli_tests.sh`), make it executable with `chmod +x mnli_tests.sh`, and execute it with `./mnli_tests.sh`. Ensure you run the script from the seacrowd root directory.

```bash
#!/bin/bash

DATASET="multilingual_nli_26lang"
LANGS=("id" "vi")
SUBSETS=("anli" "fever" "ling" "mnli" "wanli")

mkdir -p data/${DATASET}

success_count=0
fail_count=0
declare -a failed_tests

for lang in "${LANGS[@]}"; do
    for subset in "${SUBSETS[@]}"; do
        subset_id="${lang}_${subset}"
        python_command="python -m tests.test_seacrowd seacrowd/sea_datasets/${DATASET}/${DATASET}.py --subset_id=${DATASET}_${subset_id}"
        output_file="data/${DATASET}/${subset_id}.txt"
        temp_output_file="data/${DATASET}/${subset_id}_temp.txt"  # for cleaner cli output

        echo "Testing subset id: $subset_id"
        # run the test, save the output, and redirect verbose output to a temporary file
        script -q -c "$python_command" "$temp_output_file" > /dev/null
        cat "$temp_output_file" > "$output_file"
        rm "$temp_output_file"

        # check if the test was successful
        if grep -q "OK" "$output_file"; then
            echo "Test for $subset_id: SUCCESS"
            ((success_count++))
        else
            echo "Test for $subset_id: FAILURE"
            failed_tests+=("$subset_id")
            ((fail_count++))
        fi
    done
done

echo "-----------------------"
echo "SUMMARY: $((success_count + fail_count)) tests total"
echo "Success: $success_count"
echo "Failure: $fail_count"
if [ ${#failed_tests[@]} -gt 0 ]; then
    echo "Failed tests:"
    for test in "${failed_tests[@]}"; do
        echo "- $test"
    done
fi
```
</details>

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.