### PR TITLE
Closes #578 | Add Dataloader ViCon

### DIFF
--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -72,7 +72,9 @@ _URLS = {
     "verb": "https://www.ims.uni-stuttgart.de/documents/ressourcen/experiment-daten/ViData.zip",
 }
 
-_SUPPORTED_TASKS = [Tasks.WORD_ANALOGY]
+# This task is more suitable for TEXTUAL_ENTAILMENT
+# not WORD_ANALOGY task
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
 
 _SOURCE_VERSION = "1.0.0"
 

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -175,7 +175,7 @@ class ViConDataset(datasets.GeneratorBasedBuilder):
                 example = {
                     "id": str(index),
                     "text_1": str(row["Word1"]),
-                    "text_1": str(row["Word2"]),
+                    "text_2": str(row["Word2"]),
                     "label": str(row["Relation"]),
                 }
 

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -73,7 +73,7 @@ _URLS = {
 }
 
 # This task is more suitable for TEXTUAL_ENTAILMENT
-# not WORD_ANALOGY task
+# because the labels (antonym, synonym) roughly correlates to (contradiction, entailment)
 _SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
 
 _SOURCE_VERSION = "1.0.0"

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -47,8 +47,7 @@ _CITATION = """\
     url = "https://aclanthology.org/N18-2032",
     doi = "10.18653/v1/N18-2032",
     pages = "199--205",
-    abstract = "We present two novel datasets for the low-resource language Vietnamese to assess models of semantic similarity: ViCon comprises pairs of synonyms and antonyms across word classes, thus offering data to distinguish between similarity and dissimilarity. ViSim-400 provides degrees of similarity across five semantic relations, as rated by human judges. The two datasets are verified through standard co-occurrence and neural network models, showing results comparable to the respective English datasets.",
-}
+    }
 """
 
 _DATASETNAME = "vicon"

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -28,7 +28,7 @@ import pandas as pd
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @inproceedings{nguyen-etal-2018-introducing,

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -1,0 +1,187 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+ViCon, comprises pairs of synonyms and antonymys across \
+    noun, verb, and adjective classes, offerring data to \
+    distinguish between similarity and dissimilarity.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@inproceedings{nguyen-etal-2018-introducing,
+    title = "Introducing Two {V}ietnamese Datasets for Evaluating Semantic Models of (Dis-)Similarity and Relatedness",
+    author = "Nguyen, Kim Anh  and
+      Schulte im Walde, Sabine  and
+      Vu, Ngoc Thang",
+    editor = "Walker, Marilyn  and
+      Ji, Heng  and
+      Stent, Amanda",
+    booktitle = "Proceedings of the 2018 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)",
+    month = jun,
+    year = "2018",
+    address = "New Orleans, Louisiana",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/N18-2032",
+    doi = "10.18653/v1/N18-2032",
+    pages = "199--205",
+    abstract = "We present two novel datasets for the low-resource language Vietnamese to assess models of semantic similarity: ViCon comprises pairs of synonyms and antonyms across word classes, thus offering data to distinguish between similarity and dissimilarity. ViSim-400 provides degrees of similarity across five semantic relations, as rated by human judges. The two datasets are verified through standard co-occurrence and neural network models, showing results comparable to the respective English datasets.",
+}
+"""
+
+_DATASETNAME = "vicon"
+
+_DESCRIPTION = """\
+ViCon, comprises pairs of synonyms and antonymys across \
+    noun, verb, and adjective classes, offerring data to \
+    distinguish between similarity and dissimilarity.
+"""
+
+_HOMEPAGE = "https://www.ims.uni-stuttgart.de/forschung/ressourcen/experiment-daten/vnese-sem-datasets/"
+
+_LANGUAGES = ["vie"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
+_LICENSE = Licenses.CC_BY_NC_SA_2_0.value  # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_URLS = {
+    "noun": "https://www.ims.uni-stuttgart.de/documents/ressourcen/experiment-daten/ViData.zip",
+    "adj": "https://www.ims.uni-stuttgart.de/documents/ressourcen/experiment-daten/ViData.zip",
+    "verb": "https://www.ims.uni-stuttgart.de/documents/ressourcen/experiment-daten/ViData.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.WORD_ANALOGY]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class ViConDataset(datasets.GeneratorBasedBuilder):
+    """
+    ViCon, comprises pairs of synonyms and antonymys across \
+    noun, verb, and adjective classes, offerring data to \
+    distinguish between similarity and dissimilarity.
+    """
+
+    TYPES = ["noun", "adj", "verb"]
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{TYPE}_source", version=_SOURCE_VERSION, description=f"{_DATASETNAME}_{TYPE} source schema", schema="source", subset_id=f"{_DATASETNAME}_{TYPE}",) for TYPE in TYPES] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{TYPE}_seacrowd_pairs",
+            version=_SEACROWD_VERSION,
+            description=f"{_DATASETNAME}_{TYPE} SEACrowd schema",
+            schema="seacrowd_pairs",
+            subset_id=f"{_DATASETNAME}_{TYPE}",
+        )
+        for TYPE in TYPES
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_noun_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "Word1": datasets.Value("string"),
+                    "Word2": datasets.Value("string"),
+                    "Relation": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "seacrowd_pairs":
+            features = schemas.pairs_features(["ANT", "SYN"])
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        TYPE = self.config.name.split("_")[1]
+        if TYPE == "noun" or TYPE == "verb":
+            number = 400
+        elif TYPE == "adj":
+            number = 600
+
+        if TYPE in self.TYPES:
+            data_dir = dl_manager.download_and_extract(_URLS[TYPE])
+
+        else:
+            data_dir = [dl_manager.download_and_extract(_URLS[TYPE]) for TYPE in self.TYPES]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, f"ViData/ViCon/{number}_{TYPE}_pairs.txt"),
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r", encoding="utf-8") as file:
+            lines = file.readlines()
+
+        data = []
+        for line in lines:
+            columns = line.strip().split("\t")
+            data.append(columns)
+
+        df = pd.DataFrame(data[1:], columns=data[0])
+
+        for index, row in df.iterrows():
+
+            if self.config.schema == "source":
+                example = row.to_dict()
+
+            elif self.config.schema == "seacrowd_pairs":
+
+                example = {
+                    "id": str(index),
+                    "text_1": str(row["Word1"]),
+                    "text_1": str(row["Word2"]),
+                    "label": str(row["Relation"]),
+                }
+
+            yield index, example
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -86,20 +86,20 @@ class ViConDataset(datasets.GeneratorBasedBuilder):
     distinguish between similarity and dissimilarity.
     """
 
-    TYPES = ["noun", "adj", "verb"]
+    POS_TAGS = ["noun", "adj", "verb"]
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
 
-    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{TYPE}_source", version=_SOURCE_VERSION, description=f"{_DATASETNAME}_{TYPE} source schema", schema="source", subset_id=f"{_DATASETNAME}_{TYPE}",) for TYPE in TYPES] + [
+    BUILDER_CONFIGS = [SEACrowdConfig(name=f"{_DATASETNAME}_{POS_TAG}_source", version=_SOURCE_VERSION, description=f"{_DATASETNAME}_{POS_TAG} source schema", schema="source", subset_id=f"{_DATASETNAME}_{POS_TAG}",) for POS_TAG in POS_TAGS] + [
         SEACrowdConfig(
-            name=f"{_DATASETNAME}_{TYPE}_seacrowd_pairs",
+            name=f"{_DATASETNAME}_{POS_TAG}_seacrowd_pairs",
             version=_SEACROWD_VERSION,
-            description=f"{_DATASETNAME}_{TYPE} SEACrowd schema",
+            description=f"{_DATASETNAME}_{POS_TAG} SEACrowd schema",
             schema="seacrowd_pairs",
-            subset_id=f"{_DATASETNAME}_{TYPE}",
+            subset_id=f"{_DATASETNAME}_{POS_TAG}",
         )
-        for TYPE in TYPES
+        for POS_TAG in POS_TAGS
     ]
 
     DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_noun_source"
@@ -130,23 +130,23 @@ class ViConDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        TYPE = self.config.name.split("_")[1]
-        if TYPE == "noun" or TYPE == "verb":
+        POS_TAG = self.config.name.split("_")[1]
+        if POS_TAG == "noun" or POS_TAG == "verb":
             number = 400
-        elif TYPE == "adj":
+        elif POS_TAG == "adj":
             number = 600
 
-        if TYPE in self.TYPES:
-            data_dir = dl_manager.download_and_extract(_URLS[TYPE])
+        if POS_TAG in self.POS_TAGS:
+            data_dir = dl_manager.download_and_extract(_URLS[POS_TAG])
 
         else:
-            data_dir = [dl_manager.download_and_extract(_URLS[TYPE]) for TYPE in self.TYPES]
+            data_dir = [dl_manager.download_and_extract(_URLS[POS_TAG]) for POS_TAG in self.POS_TAGS]
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, f"ViData/ViCon/{number}_{TYPE}_pairs.txt"),
+                    "filepath": os.path.join(data_dir, f"ViData/ViCon/{number}_{POS_TAG}_pairs.txt"),
                     "split": "train",
                 },
             )

--- a/seacrowd/sea_datasets/vicon/vicon.py
+++ b/seacrowd/sea_datasets/vicon/vicon.py
@@ -180,7 +180,3 @@ class ViConDataset(datasets.GeneratorBasedBuilder):
                 }
 
             yield index, example
-
-
-# This template is based on the following template from the datasets package:
-# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py


### PR DESCRIPTION
**Title**: Add Dataloader ViCon

**First line PR Message**: Closes https://github.com/SEACrowd/seacrowd-datahub/issues/578

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.