### PR TITLE
Closes #623 | Add/Update Dataloader MedEV

### DIFF
--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -137,18 +137,15 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
             en_lines = f.readlines()
         with open(filepath["vie"], "r") as f:
             vie_lines = f.readlines()
-        all_lines = list(zip(en_lines, vie_lines))
 
         if self.config.schema == "source":
-
-            for i, line in enumerate(all_lines):
+            for i, line in enumerate(en_lines + vie_lines):
                 yield i, {
                     "text": line,
                 }
 
         elif self.config.schema == "seacrowd_t2t":
-
-            for i, (en_line, vie_line) in enumerate(all_lines):
+            for i, (en_line, vie_line) in enumerate(list(zip(en_lines, vie_lines))):
                 yield i, {
                     "id": str(i),
                     "text_1": en_line,

--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -49,9 +49,12 @@ _LICENSE = Licenses.UNKNOWN.value
 _LOCAL = False
 
 _URLS = {
-    "train": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.en.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.vi.txt?download=true"},
-    "val": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.en.new.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.vi.new.txt?download=true"},
-    "test": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.en.new.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.vi.new.txt?download=true"},
+    "train_en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.en.txt?download=true", 
+    "train_vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.vi.txt?download=true",
+    "val_en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.en.new.txt?download=true", 
+    "val_vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.vi.new.txt?download=true",
+    "test_en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.en.new.txt?download=true",
+    "test_vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.vi.new.txt?download=true",
 }
 
 _SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
@@ -73,14 +76,14 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
             version=SOURCE_VERSION,
             description=f"{_DATASETNAME} source schema",
             schema="source",
-            subset_id=f"{_DATASETNAME}",
+            subset_id=_DATASETNAME,
         ),
         SEACrowdConfig(
             name=f"{_DATASETNAME}_seacrowd_t2t",
             version=SEACROWD_VERSION,
             description=f"{_DATASETNAME} SEACrowd schema",
             schema="seacrowd_t2t",
-            subset_id=f"{_DATASETNAME}",
+            subset_id=_DATASETNAME,
         ),
     ]
 
@@ -91,6 +94,7 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source":
             features = datasets.Features(
                 {
+                    "id": datasets.Value("string"),
                     "text": datasets.Value("string"),
                 }
             )
@@ -114,28 +118,31 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": data_dir["train"],
+                    "filepath_en": data_dir["train_en"],
+                    "filepath_vie": data_dir["train_vie"],
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "filepath": data_dir["test"],
+                    "filepath_en": data_dir["test_en"],
+                    "filepath_vie": data_dir["test_vie"],
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "filepath": data_dir["val"],
+                    "filepath_en": data_dir["val_en"],
+                    "filepath_vie": data_dir["val_vie"],
                 },
             ),
         ]
 
-    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath_en: Path, filepath_vie: Path) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
-        with open(filepath["en"], "r", encoding="utf-8") as f:
+        with open(filepath_en, "r", encoding="utf-8") as f:
             en_lines = f.readlines()
-        with open(filepath["vie"], "r") as f:
+        with open(filepath_vie, "r", encoding="utf-8") as f:
             vie_lines = f.readlines()
 
         if self.config.schema == "source":
@@ -151,6 +158,6 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
                     "id": str(i),
                     "text_1": en_line,
                     "text_2": vie_line,
-                    "text_1_name": "en",
+                    "text_1_name": "eng",
                     "text_2_name": "vie",
                 }

--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -1,0 +1,158 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A high-quality Vietnamese-English parallel dataset constructed specifically for the medical domain, comprising approximately 360K sentence pairs
+"""
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@inproceedings{medev,
+    title     = {{Improving Vietnamese-English Medical Machine Translation}},
+    author    = {Nhu Vo and Dat Quoc Nguyen and Dung D. Le and Massimo Piccardi and Wray Buntine},
+    booktitle = {Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING)},
+    year      = {2024}
+}
+"""
+
+_DATASETNAME = "medev"
+
+_DESCRIPTION = """\
+A high-quality Vietnamese-English parallel dataset constructed specifically for the medical domain, comprising approximately 360K sentence pairs
+"""
+
+_HOMEPAGE = "https://huggingface.co/datasets/nhuvo/MedEV"
+
+_LANGUAGES = ["vie"]
+
+_LICENSE = Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_URLS = {
+    "train": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.en.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/train.vi.txt?download=true"},
+    "val": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.en.new.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/val.vi.new.txt?download=true"},
+    "test": {"en": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.en.new.txt?download=true", "vie": "https://huggingface.co/datasets/nhuvo/MedEV/resolve/main/test.vi.new.txt?download=true"},
+}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class MedEVDataset(datasets.GeneratorBasedBuilder):
+    """A high-quality Vietnamese-English parallel dataset constructed specifically for the medical domain, comprising approximately 360K sentence pairs"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    SEACROWD_VERSION = datasets.Version(_SEACROWD_VERSION)
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        ),
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_seacrowd_t2t",
+            version=SEACROWD_VERSION,
+            description=f"{_DATASETNAME} SEACrowd schema",
+            schema="seacrowd_t2t",
+            subset_id=f"{_DATASETNAME}",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "seacrowd_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        data_dir = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir["train"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir["test"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir["val"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(filepath["en"], "r") as f:
+            en_lines = f.readlines()
+        with open(filepath["vie"], "r") as f:
+            vie_lines = f.readlines()
+        all_lines = list(zip(en_lines, vie_lines))
+
+        if self.config.schema == "source":
+
+            for i, line in enumerate(all_lines):
+                yield i, {
+                    "text": line,
+                }
+
+        elif self.config.schema == "seacrowd_t2t":
+
+            for i, (en_line, vie_line) in enumerate(all_lines):
+                yield i, {
+                    "id": str(i),
+                    "text_1": en_line,
+                    "text_2": vie_line,
+                    "text_1_name": "en",
+                    "text_2_name": "vie",
+                }

--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -141,6 +141,7 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source":
             for i, line in enumerate(en_lines + vie_lines):
                 yield i, {
+                    "id": str(i),
                     "text": line,
                 }
 

--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -133,7 +133,7 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
-        with open(filepath["en"], "r") as f:
+        with open(filepath["en"], "r", encoding="utf-8") as f:
             en_lines = f.readlines()
         with open(filepath["vie"], "r") as f:
             vie_lines = f.readlines()

--- a/seacrowd/sea_datasets/medev/medev.py
+++ b/seacrowd/sea_datasets/medev/medev.py
@@ -95,7 +95,8 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
             features = datasets.Features(
                 {
                     "id": datasets.Value("string"),
-                    "text": datasets.Value("string"),
+                    "vie_text": datasets.Value("string"),
+                    "eng_text": datasets.Value("string"),
                 }
             )
 
@@ -146,10 +147,11 @@ class MedEVDataset(datasets.GeneratorBasedBuilder):
             vie_lines = f.readlines()
 
         if self.config.schema == "source":
-            for i, line in enumerate(en_lines + vie_lines):
+            for i in range(len(vie_lines)):
                 yield i, {
                     "id": str(i),
-                    "text": line,
+                    "vie_text": vie_lines[i],
+                    "eng_text": en_lines[i],
                 }
 
         elif self.config.schema == "seacrowd_t2t":


### PR DESCRIPTION
Closes #623 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [.] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

### Tests
<img width="1209" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/65403659/fbd4bdef-f274-4f87-9715-48fe4411c7b6">

