### PR TITLE
Closes #629 | Add/Update Dataloader VLSP2020 MT

### DIFF
--- a/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
+++ b/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
@@ -61,6 +61,7 @@ _SOURCE_VERSION = "1.0.0"
 
 _SEACROWD_VERSION = "1.0.0"
 
+
 class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     """
     Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain.

--- a/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
+++ b/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
@@ -24,7 +24,7 @@ import datasets
 
 from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
+from seacrowd.utils.constants import Licenses, Tasks
 
 _CITATION = """\
 @inproceedings{vlsp2020-mt,
@@ -43,7 +43,7 @@ Parallel and monolingual data for training machine translation systems translati
 
 _HOMEPAGE = "https://github.com/thanhleha-kit/EnViCorpora"
 
-_LANGUAGES = ["vie"] 
+_LANGUAGES = ["vie"]
 
 _LICENSE = Licenses.UNKNOWN.value
 
@@ -64,32 +64,32 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     subsets = {
         # key: subset_id, value: subset_filename
         "EVBCorpus" : [
-            ("bitext", datasets.Split.TRAIN)
+            ("bitext", datasets.Split.TRAIN),
         ],
         "VLSP20-official" : [
-            ("offi_test", datasets.Split.TEST)
+            ("offi_test", datasets.Split.TEST),
         ],
         "basic": [
-            ("data", datasets.Split.TRAIN)
+            ("data", datasets.Split.TRAIN),
         ],
         "indomain-news": [
             ("train", datasets.Split.TRAIN),
             ("dev", datasets.Split.VALIDATION),
-            ("tst", datasets.Split.TEST)
+            ("tst", datasets.Split.TEST),
         ],
         "iwslt15": [
             ("train", datasets.Split.TRAIN),
             ("dev", datasets.Split.VALIDATION),
-            ("test", datasets.Split.TEST)
+            ("test", datasets.Split.TEST),
         ],
         "iwslt15-official": [
-            ("IWSLT15.official_test", datasets.Split.TEST)
+            ("IWSLT15.official_test", datasets.Split.TEST),
         ],
         "ted-like": [
-            ("data", datasets.Split.TRAIN)
+            ("data", datasets.Split.TRAIN),
         ],
         "wiki-alt": [
-            ("data", datasets.Split.TRAIN)
+            ("data", datasets.Split.TRAIN),
         ]
     }
 
@@ -118,11 +118,13 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     def _info(self) -> datasets.DatasetInfo:
 
         if self.config.schema == "source":
-            features = datasets.Features({
-                "id": datasets.Value("string"),
-                "text_en": datasets.Value("string"),
-                "text_vi": datasets.Value("string"),
-            })
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text_en": datasets.Value("string"),
+                    "text_vi": datasets.Value("string"),
+                }
+            )
 
         elif self.config.schema == "seacrowd_t2t":
             features = schemas.text2text_features
@@ -140,7 +142,7 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
         subset_id = self.config.subset_id.split("_")[-1]
                 
         filenames = self.subsets[subset_id]
-        if "iwslt15" in subset_id: # for iwslt15-official
+        if "iwslt15" in subset_id:  # for iwslt15-official
             subset_id = "iwslt15"
 
         data_dir = dl_manager.download_and_extract(_URLS)
@@ -160,25 +162,25 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
-        with open(filepath["en"], 'r') as f:
+        with open(filepath["en"], "r") as f:
             en = f.readlines()
-        with open(filepath["vi"], 'r') as f:
+        with open(filepath["vi"], "r") as f:
             vi = f.readlines()
 
         if self.config.schema == "source":
             for i, (en_text, vi_text) in enumerate(zip(en, vi)):
                 yield i, {
-                        "id": str(i),
-                        "text_en": en_text.strip(), 
-                        "text_vi": vi_text.strip()
-                    }
+                    "id": str(i),
+                    "text_en": en_text.strip(), 
+                    "text_vi": vi_text.strip(),
+                }
 
         elif self.config.schema == "seacrowd_t2t":
             for i, (en_text, vi_text) in enumerate(zip(en, vi)):
                 yield i, {
-                        "id": str(i),
-                        "text_1": en_text.strip(),
-                        "text_2": vi_text.strip(),
-                        "text_1_name": "en",
-                        "text_2_name": "vi",
-                    }
+                    "id": str(i),
+                    "text_1": en_text.strip(),
+                    "text_2": vi_text.strip(),
+                    "text_1_name": "en",
+                    "text_2_name": "vi",
+                }

--- a/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
+++ b/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
@@ -63,13 +63,34 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     # Skipping openSub & mono-vi for future development (Large Drive file download bottleneck)
     subsets = {
         # key: subset_id, value: subset_filename
-        "EVBCorpus" : ["bitext"],
-        "VLSP20-official" : ["offi_test"],
-        "basic": ["data"],
-        "indomain-news": ["train", "dev", "tst"],
-        "iwslt15": ["train", "dev", "test"],
-        "ted-like": ["data"],
-        "wiki-alt": ["data"]
+        "EVBCorpus" : [
+            ("bitext", datasets.Split.TRAIN)
+        ],
+        "VLSP20-official" : [
+            ("offi_test", datasets.Split.TEST)
+        ],
+        "basic": [
+            ("data", datasets.Split.TRAIN)
+        ],
+        "indomain-news": [
+            ("train", datasets.Split.TRAIN),
+            ("dev", datasets.Split.VALIDATION),
+            ("tst", datasets.Split.TEST)
+        ],
+        "iwslt15": [
+            ("train", datasets.Split.TRAIN),
+            ("dev", datasets.Split.VALIDATION),
+            ("test", datasets.Split.TEST)
+        ],
+        "iwslt15-official": [
+            ("IWSLT15.official_test", datasets.Split.TEST)
+        ],
+        "ted-like": [
+            ("data", datasets.Split.TRAIN)
+        ],
+        "wiki-alt": [
+            ("data", datasets.Split.TRAIN)
+        ]
     }
 
     BUILDER_CONFIGS = [
@@ -117,23 +138,24 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         subset_id = self.config.subset_id.split("_")[-1]
-        
-        splitnames = [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]
+                
         filenames = self.subsets[subset_id]
+        if "iwslt15" in subset_id: # for iwslt15-official
+            subset_id = "iwslt15"
 
         data_dir = dl_manager.download_and_extract(_URLS)
 
         return [
             datasets.SplitGenerator(
-                name=splitnames[i],
+                name=splitname,
                 gen_kwargs={
                     "filepath": {
-                        "en": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filenames[i]}.en"),
-                        "vi": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filenames[i]}.vi"),
+                        "en": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filename}.en"),
+                        "vi": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filename}.vi"),
                     },
                 },
             )
-            for i in range(len(filenames))
+            for filename, splitname in filenames
         ]
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:

--- a/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
+++ b/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
@@ -1,0 +1,162 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
+"""
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
+
+_CITATION = """\
+@inproceedings{vlsp2020-mt,
+title     = {{Goals, Challenges and Findings of the VLSP 2020 English-Vietnamese News Translation Shared Task}},
+author    = {Thanh-Le Ha and Van-Khanh Tran and Kim-Anh Nguyen},
+booktitle = {{Proceedings of the 7th International Workshop on Vietnamese Language and Speech Processing - VLSP 2020}},
+year      = {2020}
+}
+"""
+
+_DATASETNAME = "vlsp2020_mt_envi"
+
+_DESCRIPTION = """\
+Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
+"""
+
+_HOMEPAGE = "https://github.com/thanhleha-kit/EnViCorpora"
+
+_LANGUAGES = ["vie"] 
+
+_LICENSE = Licenses.UNKNOWN.value
+
+_LOCAL = False
+
+_URLS = "https://github.com/thanhleha-kit/EnViCorpora/archive/refs/heads/master.zip"
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
+    """Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset."""
+
+    # Skipping openSub & mono-vi for future development (Large Drive file download bottleneck)
+    subsets = {
+        # key: subset_id, value: subset_filename
+        "EVBCorpus" : ["bitext"],
+        "VLSP20-official" : ["offi_test"],
+        "basic": ["data"],
+        "indomain-news": ["train", "dev", "tst"],
+        "iwslt15": ["train", "dev", "test"],
+        "ted-like": ["data"],
+        "wiki-alt": ["data"]
+    }
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{subset}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description=f"{_DATASETNAME}_{subset} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}_{subset}",
+        )
+        for subset in list(subsets.keys())
+    ] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{subset}_seacrowd_t2t",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"{_DATASETNAME}_{subset} SEACrowd schema",
+            schema="seacrowd_t2t",
+            subset_id=f"{_DATASETNAME}_{subset}",
+        )
+        for subset in list(subsets.keys())
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_VLSP20-official_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features({
+                "id": datasets.Value("string"),
+                "text_en": datasets.Value("string"),
+                "text_vi": datasets.Value("string"),
+            })
+
+        elif self.config.schema == "seacrowd_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        subset_id = self.config.subset_id.split("_")[-1]
+        
+        splitnames = [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]
+        filenames = self.subsets[subset_id]
+
+        data_dir = dl_manager.download_and_extract(_URLS)
+
+        return [
+            datasets.SplitGenerator(
+                name=splitnames[i],
+                gen_kwargs={
+                    "filepath": {
+                        "en": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filenames[i]}.en"),
+                        "vi": os.path.join(data_dir, "EnViCorpora-master", subset_id, f"{filenames[i]}.vi"),
+                    },
+                },
+            )
+            for i in range(len(filenames))
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(filepath["en"], 'r') as f:
+            en = f.readlines()
+        with open(filepath["vi"], 'r') as f:
+            vi = f.readlines()
+
+        if self.config.schema == "source":
+            for i, (en_text, vi_text) in enumerate(zip(en, vi)):
+                yield i, {
+                        "id": str(i),
+                        "text_en": en_text.strip(), 
+                        "text_vi": vi_text.strip()
+                    }
+
+        elif self.config.schema == "seacrowd_t2t":
+            for i, (en_text, vi_text) in enumerate(zip(en, vi)):
+                yield i, {
+                        "id": str(i),
+                        "text_1": en_text.strip(),
+                        "text_2": vi_text.strip(),
+                        "text_1_name": "en",
+                        "text_2_name": "vi",
+                    }

--- a/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
+++ b/seacrowd/sea_datasets/vlsp2020_mt_envi/vlsp2020_mt_envi.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 """
-Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
+Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain.
+The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks).
+The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
 """
 import os
 from pathlib import Path
@@ -38,7 +40,9 @@ year      = {2020}
 _DATASETNAME = "vlsp2020_mt_envi"
 
 _DESCRIPTION = """\
-Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
+Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain.
+The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks).
+The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
 """
 
 _HOMEPAGE = "https://github.com/thanhleha-kit/EnViCorpora"
@@ -58,15 +62,19 @@ _SOURCE_VERSION = "1.0.0"
 _SEACROWD_VERSION = "1.0.0"
 
 class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
-    """Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain. The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks). The dataset also includes noisy movie subtitles from the OpenSubtitle dataset."""
+    """
+    Parallel and monolingual data for training machine translation systems translating English texts into Vietnamese, with a focus on news domain.
+    The data was crawled from high-quality bilingual or multilingual websites of news and one-speaker educational talks on various topics, mostly technology, entertainment, and design (hereby referred to as TED-like talks).
+    The dataset also includes noisy movie subtitles from the OpenSubtitle dataset.
+    """
 
     # Skipping openSub & mono-vi for future development (Large Drive file download bottleneck)
     subsets = {
         # key: subset_id, value: subset_filename
-        "EVBCorpus" : [
+        "EVBCorpus": [
             ("bitext", datasets.Split.TRAIN),
         ],
-        "VLSP20-official" : [
+        "VLSP20-official": [
             ("offi_test", datasets.Split.TEST),
         ],
         "basic": [
@@ -90,7 +98,7 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
         ],
         "wiki-alt": [
             ("data", datasets.Split.TRAIN),
-        ]
+        ],
     }
 
     BUILDER_CONFIGS = [
@@ -140,7 +148,7 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         subset_id = self.config.subset_id.split("_")[-1]
-                
+
         filenames = self.subsets[subset_id]
         if "iwslt15" in subset_id:  # for iwslt15-official
             subset_id = "iwslt15"
@@ -171,7 +179,7 @@ class Vlsp2020MtEnviDataset(datasets.GeneratorBasedBuilder):
             for i, (en_text, vi_text) in enumerate(zip(en, vi)):
                 yield i, {
                     "id": str(i),
-                    "text_en": en_text.strip(), 
+                    "text_en": en_text.strip(),
                     "text_vi": vi_text.strip(),
                 }
 


### PR DESCRIPTION
Closes #629 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [.] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

### Tests
#### indomain-news (3 splits)
<img width="1154" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/65403659/814dfa71-e1a5-4899-bad8-cc34c0ca40c7">

#### basic (1 split)
<img width="1097" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/65403659/93cdc0bc-734d-41e1-a097-a891cc75c143">

#### VLSP20-official (1 split)
<img width="1028" alt="image" src="https://github.com/SEACrowd/seacrowd-datahub/assets/65403659/0382c314-74e9-48ce-a666-46ab180a8e24">

**NB**
- Skipping `openSub` & `mono-vi` for future development (Large Drive file download bottleneck), already opened thread in Discord discussion.
- Tested 3 out of 7 subsets

