### PR TITLE
Import `schemas` beforehand on `templates/template.py`

### DIFF
--- a/templates/template.py
+++ b/templates/template.py
@@ -34,7 +34,9 @@ from typing import Dict, List, Tuple
 
 import datasets
 
+from seacrowd.utils import schemas
 from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Tasks, Licenses
 
 # TODO: Add BibTeX citation
 _CITATION = """\
@@ -72,7 +74,7 @@ _LANGUAGES = []  # We follow ISO639-3 language code (https://iso639-3.sil.org/co
 # In the case of the dataset intentionally is built without license, please use `Licenses.UNLICENSE.value`
 # In the case that it's not clear whether the dataset has a license or not, please use `Licenses.UNKNOWN.value`
 # Some datasets may also have custom licenses. In this case, simply put f'{Licenses.OTHERS.value} | {FULL_LICENSE_TERM}' into `_LICENSE`
-_LICENSE = ""  # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
+_LICENSE = "" # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
 
 # TODO: Add a _LOCAL flag to indicate whether the data cannot be sourced from a public link
 #  E.g. the dataset requires signing a specific term of use, the dataset is sent through email, etc.

--- a/templates/template.py
+++ b/templates/template.py
@@ -35,7 +35,6 @@ from typing import Dict, List, Tuple
 import datasets
 
 from seacrowd.utils.configs import SEACrowdConfig
-from seacrowd.utils.constants import Tasks, Licenses
 
 # TODO: Add BibTeX citation
 _CITATION = """\
@@ -73,9 +72,9 @@ _LANGUAGES = []  # We follow ISO639-3 language code (https://iso639-3.sil.org/co
 # In the case of the dataset intentionally is built without license, please use `Licenses.UNLICENSE.value`
 # In the case that it's not clear whether the dataset has a license or not, please use `Licenses.UNKNOWN.value`
 # Some datasets may also have custom licenses. In this case, simply put f'{Licenses.OTHERS.value} | {FULL_LICENSE_TERM}' into `_LICENSE`
-_LICENSE = "" # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
+_LICENSE = ""  # example: Licenses.MIT.value, Licenses.CC_BY_NC_SA_4_0.value, Licenses.UNLICENSE.value, Licenses.UNKNOWN.value
 
-# TODO: Add a _LOCAL flag to indicate whether the data cannot be sourced from a public link 
+# TODO: Add a _LOCAL flag to indicate whether the data cannot be sourced from a public link
 #  E.g. the dataset requires signing a specific term of use, the dataset is sent through email, etc.
 _LOCAL = False
 
@@ -101,7 +100,7 @@ _SOURCE_VERSION = ""
 _SEACROWD_VERSION = "1.0.0"
 
 
-# TODO: Name the dataset class to match the script name using PascalCase instead of snake_case. 
+# TODO: Name the dataset class to match the script name using PascalCase instead of snake_case.
 # optional: class name can append "Dataset" as suffix to provide better clarity (e.g. OSCAR 2201 --> Oscar2201Dataset/Oscar2201)
 class NewDataset(datasets.GeneratorBasedBuilder):
     """TODO: Short description of my dataset."""


### PR DESCRIPTION
**Issue**: This PR simply adds the schemas import statement in `templates/template.py` (`from seacrowd.utils import schemas`). This is to ease the `_info(self)` section for the seacrowd schema.

After working on the data loader multiple times, I had to manually (or automatically) import to fill in that code section. By importing schemas beforehand, it at least eases (a bit) the repetitive issue.