### PR TITLE
Add `.upper` method for `--schema` parameter

### DIFF
--- a/tests/test_seacrowd.py
+++ b/tests/test_seacrowd.py
@@ -11,8 +11,8 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 
 import datasets
 from datasets import DatasetDict, Features
-from seacrowd.utils.constants import TASK_TO_SCHEMA, VALID_TASKS, VALID_SCHEMAS, SCHEMA_TO_FEATURES, TASK_TO_FEATURES
-from seacrowd.utils.schemas import kb_features
+from seacrowd.utils.constants import Tasks, TASK_TO_SCHEMA, VALID_TASKS, VALID_SCHEMAS, SCHEMA_TO_FEATURES, TASK_TO_FEATURES
+from seacrowd.utils.schemas import kb_features, pairs_features, pairs_features_score, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, speech_text_features, image_text_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -150,7 +150,7 @@ class TestDataLoader(unittest.TestCase):
             )
 
         # check dataset samples
-        for schema in ["source"] + [f"seacrowd_{s.lower()}" for s in self.schemas_to_check]:
+        for schema in ['source'] + [f"seacrowd_{s.lower()}" for s in self.schemas_to_check]:
             dataset = datasets.load_dataset(
                 self.PATH,
                 name=f"{self.SUBSET_ID}_{schema}",
@@ -158,6 +158,7 @@ class TestDataLoader(unittest.TestCase):
                 use_auth_token=self.USE_AUTH_TOKEN,
             )
             logger.info(f"Dataset sample [{schema}]\n{dataset[list(dataset.keys())[0]][0]}")
+
 
     def get_feature_statistics(self, features: Features, schema: str) -> Dict:
         """

--- a/tests/test_seacrowd.py
+++ b/tests/test_seacrowd.py
@@ -11,8 +11,8 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 
 import datasets
 from datasets import DatasetDict, Features
-from seacrowd.utils.constants import Tasks, TASK_TO_SCHEMA, VALID_TASKS, VALID_SCHEMAS, SCHEMA_TO_FEATURES, TASK_TO_FEATURES
-from seacrowd.utils.schemas import kb_features, pairs_features, pairs_features_score, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, speech_text_features, image_text_features
+from seacrowd.utils.constants import TASK_TO_SCHEMA, VALID_TASKS, VALID_SCHEMAS, SCHEMA_TO_FEATURES, TASK_TO_FEATURES
+from seacrowd.utils.schemas import kb_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -150,7 +150,7 @@ class TestDataLoader(unittest.TestCase):
             )
 
         # check dataset samples
-        for schema in ['source'] + [f"seacrowd_{s.lower()}" for s in self.schemas_to_check]:
+        for schema in ["source"] + [f"seacrowd_{s.lower()}" for s in self.schemas_to_check]:
             dataset = datasets.load_dataset(
                 self.PATH,
                 name=f"{self.SUBSET_ID}_{schema}",
@@ -158,7 +158,6 @@ class TestDataLoader(unittest.TestCase):
                 use_auth_token=self.USE_AUTH_TOKEN,
             )
             logger.info(f"Dataset sample [{schema}]\n{dataset[list(dataset.keys())[0]][0]}")
-
 
     def get_feature_statistics(self, features: Features, schema: str) -> Dict:
         """
@@ -527,7 +526,7 @@ if __name__ == "__main__":
     parser.add_argument("path", type=str, help="path to dataloader script (e.g. examples/n2c2_2011.py)")
     parser.add_argument(
         "--schema",
-        type=str,
+        type=str.upper,
         default=None,
         required=False,
         choices=list(VALID_SCHEMAS),


### PR DESCRIPTION
**Issue**:

This is also a (**really**) minor thing that I noticed when running tests with the `--schema` parameter.

I noticed that all the items in the `VALID_SCHEMAS` variable are strings in full capital letters, there are no strings in lowercase letters (except for `NoneType`).

Therefore, by changing the line:

```
parser.add_argument(
      "--schema",
      type=str,
      ...
```

to:

```
parser.add_argument(
      "--schema",
      type=str.upper,
      ...
```

Automate the conversion of the `--schema` parameter input by the user. Especially since the general habit is to type in lowercase.

Although this is a very simple thing, it is better to automate it.