### PR TITLE
Closes #474 | Add Dataloader OKAPI mARC

### DIFF
--- a/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
+++ b/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
@@ -1,0 +1,188 @@
+"""This file is a modified version of the file by Natural Language Processing Group at the University of Oregon.
+Authors: Chien Nguyen et al. 2023
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """\
+@article{dac2023okapi,
+  title={Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback},
+  author={Dac Lai, Viet and Van Nguyen, Chien and Ngo, Nghia Trung and Nguyen, Thuat and Dernoncourt, Franck and Rossi, Ryan A and Nguyen, Thien Huu},
+  journal={arXiv e-prints},
+  pages={arXiv--2307},
+  year={2023}
+}
+
+@article{Clark2018ThinkYH,
+  title={Think you have Solved Question Answering? Try ARC, the AI2 Reasoning Challenge},
+  author={Peter Clark and Isaac Cowhey and Oren Etzioni and Tushar Khot and Ashish Sabharwal and Carissa Schoenick and Oyvind Tafjord},
+  journal={ArXiv},
+  year={2018},
+  volume={abs/1803.05457}
+}
+"""
+
+_DATASETNAME = "okapi_m_arc"
+
+_DESCRIPTION = """\
+mARC is a Multilingual translation of AI2's Arc Challenge from the paper "Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback" (Lai et al., 2023). The original ARC dataset is a multiple-choice question answering dataset of 7,787 genuine grade-school level science questions assembled to encourage research in advanced question-answering. The dataset is partitioned into a Challenge Set and an Easy Set, where the former contains only questions answered incorrectly by both a retrieval-based algorithm and a word co-occurrence algorithm. We also include a corpus of over 14 million science sentences relevant to the task and an implementation of three neural baseline models for this dataset. We pose ARC as a challenge to the community.
+"""
+
+
+_HOMEPAGE = "https://huggingface.co/datasets/jon-tow/okapi_arc_challenge"
+_LICENSE = Licenses.CC_BY_NC_4_0.value
+_LOCAL = False
+_LANGUAGES = ["ind", "vie"]
+
+_LANG_MAP = {"ind": "id", "vie": "vi"}
+_URLS = {
+    "base_url": "https://huggingface.co/datasets/jon-tow/okapi_arc_challenge/resolve/main",
+}
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_SEACROWD_VERSION = "1.0.0"
+
+class MultilingualArc(datasets.GeneratorBasedBuilder):
+    """mARC is a Multilingual translation of AI2's Arc Challenge which is a multiple-choice question answering dataset 
+    of 7,787 genuine grade-school level science questions assembled to encourage research in advanced question-answering"""
+
+    BUILDER_CONFIGS = (
+        [
+            SEACrowdConfig(
+                name="okapi_m_arc_vie_source",
+                version=datasets.Version(_SOURCE_VERSION),
+                description="Vietnamese mARC source schema",
+                schema="source",
+                subset_id="okapi_m_arc_vie_source",
+            ),
+            SEACrowdConfig(
+                name="okapi_m_arc_ind_source",
+                version=datasets.Version(_SOURCE_VERSION),
+                description="Indonesian mARC source schema",
+                schema="source",
+                subset_id="okapi_m_arc_ind_source",
+            ),
+            SEACrowdConfig(
+                name="okapi_m_arc_vie_seacrowd_qa",
+                version=datasets.Version(_SEACROWD_VERSION),
+                description="Vietnamese SEACrowd question answering schema",
+                schema="seacrowd_qa",
+                subset_id="okapi_m_arc_vie_seacrowd_qa",
+            ),
+            SEACrowdConfig(
+                name="okapi_m_arc_ind_seacrowd_qa",
+                version=datasets.Version(_SEACROWD_VERSION),
+                description="Indonesian SEACrowd question answering schema",
+                schema="seacrowd_qa",
+                subset_id="okapi_m_arc_ind_seacrowd_qa",
+            )
+        ]
+    )
+
+    DEFAULT_CONFIG_NAME = "okapi_m_arc_ind_seacrowd_qa"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "question": datasets.Value("string"),
+                    "choices": datasets.features.Sequence(
+                        {
+                            "text": datasets.Value("string"),
+                            "label": datasets.Value("string"),
+                        }
+                    ),
+                    "answerKey": datasets.Value("string"),
+                }
+            )
+        else:
+            features = schemas.qa_features
+            
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        lang = self.config.subset_id[:-(len(self.config.schema)+1)].split('_')[-1]
+        train_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_train.json"))
+        valid_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_validation.json"))
+        test_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_test.json"))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_path
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": valid_path
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_path
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """Yields examples."""
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+            
+        for i, d in enumerate(data):
+            text_choices = []
+            label_choices = []
+            if "option_a" in d:
+                text_choices.append(d["option_a"])
+                label_choices.append("A")
+            if "option_b" in d:
+                text_choices.append(d["option_b"])
+                label_choices.append("B")
+            if "option_c" in d:
+                text_choices.append(d["option_c"])
+                label_choices.append("C")
+            if "option_d" in d:
+                text_choices.append(d["option_d"])
+                label_choices.append("D")
+            if "option_e" in d:
+                text_choices.append(d["option_e"])
+                label_choices.append("E")
+
+            if self.config.schema == "source":
+                yield i, {
+                    "id": d["id"],
+                    "answerKey": d["answer"],
+                    "question": d["instruction"],
+                    "choices": {"text": text_choices, "label": label_choices},
+                }
+            else:
+                yield i, {
+                    "id": i,
+                    "question_id": d["id"],
+                    "document_id": d["id"],
+                    "question": d["instruction"],
+                    "type": 'multiple_choice',
+                    "choices": [f'{label}. {text}'for label, text in zip(label_choices, text_choices)],
+                    "context": None,
+                    "answer": [f'{d["answer"]}. {text_choices[ord(d["answer"])-65]}'],
+                    "meta": {}
+                }

--- a/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
+++ b/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
@@ -73,14 +73,14 @@ class MultilingualArc(datasets.GeneratorBasedBuilder):
             SEACrowdConfig(
                 name="okapi_m_arc_vie_seacrowd_qa",
                 version=datasets.Version(_SEACROWD_VERSION),
-                description="Vietnamese SEACrowd question answering schema",
+                description="Vietnamese mARC SEACrowd question answering schema",
                 schema="seacrowd_qa",
                 subset_id="okapi_m_arc_vie_seacrowd_qa",
             ),
             SEACrowdConfig(
                 name="okapi_m_arc_ind_seacrowd_qa",
                 version=datasets.Version(_SEACROWD_VERSION),
-                description="Indonesian SEACrowd question answering schema",
+                description="Indonesian mARC SEACrowd question answering schema",
                 schema="seacrowd_qa",
                 subset_id="okapi_m_arc_ind_seacrowd_qa",
             )

--- a/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
+++ b/seacrowd/sea_datasets/okapi_m_arc/okapi_m_arc.py
@@ -1,7 +1,3 @@
-"""This file is a modified version of the file by Natural Language Processing Group at the University of Oregon.
-Authors: Chien Nguyen et al. 2023
-"""
-
 import json
 import os
 from pathlib import Path
@@ -34,7 +30,10 @@ _CITATION = """\
 _DATASETNAME = "okapi_m_arc"
 
 _DESCRIPTION = """\
-mARC is a Multilingual translation of AI2's Arc Challenge from the paper "Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback" (Lai et al., 2023). The original ARC dataset is a multiple-choice question answering dataset of 7,787 genuine grade-school level science questions assembled to encourage research in advanced question-answering. The dataset is partitioned into a Challenge Set and an Easy Set, where the former contains only questions answered incorrectly by both a retrieval-based algorithm and a word co-occurrence algorithm. We also include a corpus of over 14 million science sentences relevant to the task and an implementation of three neural baseline models for this dataset. We pose ARC as a challenge to the community.
+mARC is a Multilingual translation of AI2's Arc Challenge from the paper "Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback" (Lai et al., 2023). 
+The original ARC dataset is a multiple-choice question answering dataset of 7,787 genuine grade-school level science questions assembled to encourage research in advanced question-answering. 
+The dataset is partitioned into a Challenge Set and an Easy Set, where the former contains only questions answered incorrectly by both a retrieval-based algorithm and a word co-occurrence algorithm. 
+We also include a corpus of over 14 million science sentences relevant to the task and an implementation of three neural baseline models for this dataset. We pose ARC as a challenge to the community.
 """
 
 
@@ -122,6 +121,7 @@ class MultilingualArc(datasets.GeneratorBasedBuilder):
         train_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_train.json"))
         valid_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_validation.json"))
         test_path = Path(dl_manager.download_and_extract(f"{_URLS['base_url']}/data/{_LANG_MAP[lang]}_test.json"))
+
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,


### PR DESCRIPTION
Closes #474

### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

Test Indonesian subset: `./test_example.sh okapi_m_arc --subset_id okapi_m_arc_ind`
Test Vietnamese subset:  `./test_example.sh okapi_m_arc --subset_id okapi_m_arc_vie`