### PR TITLE
Closes #533 | Add Dataloader XED

### DIFF
--- a/seacrowd/sea_datasets/xed/xed.py
+++ b/seacrowd/sea_datasets/xed/xed.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from seacrowd.utils import schemas
+from seacrowd.utils.configs import SEACrowdConfig
+from seacrowd.utils.constants import Licenses, Tasks
+
+_CITATION = """
+@inproceedings{ohman2020xed,
+  title={{XED}: A Multilingual Dataset for Sentiment Analysis and Emotion Detection},
+  author={{\"O}hman, Emily and P{`a}mies, Marc and Kajava, Kaisla and Tiedemann, J{\"o}rg},
+  booktitle={The 28th International Conference on Computational Linguistics (COLING 2020)},
+  year={2020}
+}
+"""
+_DATASETNAME = "xed"
+
+_DESCRIPTION = """\
+This is the XED dataset. The dataset consists of emotion annotated movie subtitles
+from OPUS. We use Plutchik's 8 core emotions to annotate. The data is multilabel.
+The original annotations have been sourced for mainly English and Finnish, with the
+rest created using annotation projection to aligned subtitles in 41 additional languages,
+with 31 languages included in the final dataset (more than 950 lines of annotated subtitle
+lines). The dataset is an ongoing project with forthcoming additions such as machine translated datasets.
+"""
+
+_HOMEPAGE = "https://github.com/Helsinki-NLP/XED"
+
+_LANGUAGES = ["ind", "vie"]
+
+# This License is from the bottom of homepage's README not Unknown (as from Issues)
+_LICENSE = Licenses.CC_BY_4_0.value
+
+_LOCAL = False
+
+_URLS = {"ind": "https://raw.githubusercontent.com/Helsinki-NLP/XED/master/Projections/id-projections.tsv", "vie": "https://raw.githubusercontent.com/Helsinki-NLP/XED/master/Projections/vi-projections.tsv"}
+
+# Because of the multi-label attribute, I choose ASPECT_BASED_SENTIMENT_ANALYSIS than SENTIMENT_ANALYSIS
+_SUPPORTED_TASKS = [Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS]
+
+_SOURCE_VERSION = "1.0.0"
+
+_SEACROWD_VERSION = "1.0.0"
+
+
+class XEDDataset(datasets.GeneratorBasedBuilder):
+    """
+    This is the XED dataset. The dataset consists of emotion annotated movie subtitles
+    from OPUS. We use Plutchik's 8 core emotions to annotate. The data is multilabel.
+    The original annotations have been sourced for mainly English and Finnish, with the
+    rest created using annotation projection to aligned subtitles in 41 additional languages,
+    with 31 languages included in the final dataset (more than 950 lines of annotated subtitle
+    lines). The dataset is an ongoing project with forthcoming additions such as machine translated datasets.
+    """
+
+    BUILDER_CONFIGS = [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{LANG}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description=f"{_DATASETNAME} {LANG} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}_{LANG}",
+        )
+        for LANG in _LANGUAGES
+    ] + [
+        SEACrowdConfig(
+            name=f"{_DATASETNAME}_{LANG}_seacrowd_text_multi",
+            version=datasets.Version(_SEACROWD_VERSION),
+            description=f"{_DATASETNAME} {LANG} SEACrowd schema",
+            schema="seacrowd_text_multi",
+            subset_id=f"{_DATASETNAME}_{LANG}",
+        )
+        for LANG in _LANGUAGES
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_ind_source"
+    _LABELS = ["Anger", "Anticipation", "Disgust", "Fear", "Joy", "Sadness", "Surprise", "Trust"]
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features({"Sentence": datasets.Value("string"), "Emotions": datasets.Sequence(feature=datasets.ClassLabel(names=self._LABELS))})
+
+        elif self.config.schema == "seacrowd_text_multi":
+            features = schemas.text_multi_features(self._LABELS)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        language = self.config.name.split("_")[1]
+
+        if language in _LANGUAGES:
+            data_path = Path(dl_manager.download_and_extract(_URLS[language]))
+        else:
+            data_path = [Path(dl_manager.download_and_extract(_URLS[language])) for language in _LANGUAGES]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_path,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        emotions_mapping = {1: "Anger", 2: "Anticipation", 3: "Disgust", 4: "Fear", 5: "Joy", 6: "Sadness", 7: "Surprise", 8: "Trust"}
+
+        df = pd.read_csv(filepath, sep="\t", names=["Sentence", "Emotions"], index_col=None)
+        df["Emotions"] = df["Emotions"].apply(lambda x: list(map(int, x.split(", "))))
+        df["Emotions"] = df["Emotions"].apply(lambda x: [emotions_mapping[emotion] for emotion in x])
+
+        for index, row in df.iterrows():
+
+            if self.config.schema == "source":
+                example = row.to_dict()
+
+            elif self.config.schema == "seacrowd_text_multi":
+
+                example = {
+                    "id": str(index),
+                    "text": str(row["Sentence"]),
+                    "labels": row["Emotions"],
+                }
+
+            yield index, example


### PR DESCRIPTION
**Title**: Add Dataloader XED

**First line PR Message**: Closes https://github.com/SEACrowd/seacrowd-datahub/issues/533

Note: 
- I changed the `_LICENSE` by `Licenses.CC_BY_4_0.value` despite of license information on the dataloader issue here https://github.com/SEACrowd/seacrowd-datahub/issues/533 is `Licenses.UNKNOWN.value`. I'd rather take license information from the bottom of [homepage's](https://github.com/Helsinki-NLP/XED) `README.md`.
- I also changed the `_SUPPORTED_TASKS` to `Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS` instead of `Tasks.SENTIMENT_ANALYSIS` due to the fact that this dataset is multi-label, so I will need `text_multi` as schema not `text`.
- From the homepage, I found that Indonesian is already there (it's already told on this comment: https://github.com/SEACrowd/seacrowd-datahub/issues/533#issuecomment-2003237075). So, I add the Indonesian dataloader too for this dataset --> I changed the `_LANGUAGES` to `["ind", "vie"]`.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
