### PR TITLE
Fix `abs`, `bhp` and `bug` languages issue on `SEACrowd/nusatranslation_mt`

### DIFF
--- a/seacrowd/sea_datasets/nusatranslation_mt/nusatranslation_mt.py
+++ b/seacrowd/sea_datasets/nusatranslation_mt/nusatranslation_mt.py
@@ -14,7 +14,7 @@ _DATASETNAME = "nusatranslation_mt"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
 _UNIFIED_VIEW_NAME = DEFAULT_SEACROWD_VIEW_NAME
 
-_LANGUAGES = ["ind", "btk", "bew", "bug", "jav", "mad", "mak", "min", "mui", "rej", "sun"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_LANGUAGES = ["ind", "abs", "bhp", "bew", "btk", "jav", "mad", "mak", "min", "mui", "rej", "sun"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 _LOCAL = False
 
 _CITATION = """\
@@ -62,6 +62,8 @@ LANGUAGES_MAP = {
     "rej": "rejang",
     "sun": "sundanese",
 }
+
+assert set(LANGUAGES_MAP.keys()).issubset(set(_LANGUAGES))
 
 
 class NusaTranslationMT(datasets.GeneratorBasedBuilder):


### PR DESCRIPTION
I wanna report that there are bugs in the that NusaTranslationMT dataloader on [SEACrowd HF](https://github.com/SEACrowd/seacrowd-datahub/blob/master/seacrowd/sea_datasets/nusatranslation_mt/nusatranslation_mt.py).

1. There is `abs` language on the `LANGUAGES_MAP` and the URL is exists (https://raw.githubusercontent.com/IndoNLP/nusa-writes/main/data/nusa_kalimat-mt-abs-train.csv), but doesn't exist on `_LANGUAGES` variable, so it cannot be reached.
2. The case is same like (1) for `bhp` language.
3. Now, the case is a little inverted here. There is no `bug` language on `LANGUGES_MAP` and the URL isn't exists, but it exist on `_LANGUAGES` variable, so it caused error `FileNotFound`.

Furthermore, I added `assert` statement to ensure the `LANGUGES_MAP` is a correct subset of `_LANGUAGES`. I think we need to check all `NusaWrites` works to make sure that this bug doesn't occur there.