### PR TITLE
Refactor FLORES-200 script

### DIFF
--- a/seacrowd/sea_datasets/flores200/flores200.py
+++ b/seacrowd/sea_datasets/flores200/flores200.py
@@ -449,7 +449,7 @@ class Flores200(datasets.GeneratorBasedBuilder):
             
             lang = self.config.language_name
             lang_df = split_df.loc[(split_df['iso_639_3'] == lang.split('_')[0]) & (split_df['iso_15924'] == lang.split('_')[1])]
-            for id_, row in enumerate(lang_df.to_dict(orient='record')):
+            for id_, row in enumerate(lang_df.to_dict(orient='records')):
                 yield id_, row
                 
         elif self.config.schema == f"seacrowd_{str(TASK_TO_SCHEMA[Tasks.MACHINE_TRANSLATION]).lower()}":
@@ -463,7 +463,7 @@ class Flores200(datasets.GeneratorBasedBuilder):
             mt_df['text_1_name'] = mt_df.apply(lambda x: f"{x['iso_639_3_x']}_{x['iso_15924_x']}", axis='columns')
             mt_df['text_2_name'] = mt_df.apply(lambda x: f"{x['iso_639_3_y']}_{x['iso_15924_y']}", axis='columns')
             
-            for id_, row in enumerate(mt_df[['id', 'text_1', 'text_2', 'text_1_name', 'text_2_name']].to_dict(orient='record')):
+            for id_, row in enumerate(mt_df[['id', 'text_1', 'text_2', 'text_1_name', 'text_2_name']].to_dict(orient='records')):
                 yield id_, row
                 
         else:


### PR DESCRIPTION
Refactor FLORES-200 script change source schema & update script for loading the new FLORES-200 v2.0 from `openlanguagedata/flores_plus`

Please name your PR title and the first line of PR message after the issue it will close. You can use the following examples:

**Title**: Update FLORES-200  

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `seacrowd/sea_datasets/{my_dataset}/{my_dataset}.py` (please use only lowercase and underscore for dataset folder naming, as mentioned in dataset issue) and its `__init__.py` within `{my_dataset}` folder.
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_LOCAL`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_SEACROWD_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `SEACrowdConfig` for the source schema and one for a seacrowd schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py` or `python -m tests.test_seacrowd seacrowd/sea_datasets/<my_dataset>/<my_dataset>.py --subset_id {subset_name_without_source_or_seacrowd_suffix}`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

Note: the `source` and `seacrowd_t2t` have completely different schema now, where the `source `only has the sentence for a certain language (as how it is implemented in `openlanguagedata/flores_plus`) and the `seacrowd_t2t` is implemented for the actual MT task.